### PR TITLE
Fix error name of configmap for leader election

### DIFF
--- a/install/samples/lazyload/slimeboot_lazyload.yaml
+++ b/install/samples/lazyload/slimeboot_lazyload.yaml
@@ -8,7 +8,7 @@ spec:
   image:
     pullPolicy: Always
     repository: docker.io/slimeio/slime-lazyload
-    tag: v0.2.1
+    tag: v0.2.2
   module:
     - name: lazyload
       enable: true

--- a/install/samples/plugin/slimeboot_plugin.yaml
+++ b/install/samples/plugin/slimeboot_plugin.yaml
@@ -10,4 +10,4 @@ spec:
   image:
     pullPolicy: Always
     repository: docker.io/slimeio/slime-plugin
-    tag: v0.2.1
+    tag: v0.2.2

--- a/slime-modules/lazyload/main.go
+++ b/slime-modules/lazyload/main.go
@@ -62,7 +62,7 @@ func main() {
 		MetricsBindAddress: metricsAddr,
 		Port:               9443,
 		LeaderElection:     enableLeaderElection,
-		LeaderElectionID:   "plugin",
+		LeaderElectionID:   "lazyload",
 	})
 	if err != nil {
 		log.Errorf("unable to start manager,%+v", err)

--- a/slime-modules/plugin/main.go
+++ b/slime-modules/plugin/main.go
@@ -60,7 +60,7 @@ func main() {
 		MetricsBindAddress: metricsAddr,
 		Port:               9443,
 		LeaderElection:     enableLeaderElection,
-		LeaderElectionID:   "9487b5c0.my.domain",
+		LeaderElectionID:   "plugin",
 	})
 	if err != nil {
 		log.Errorf("unable to start manager,%+v", err)

--- a/test/e2e/testdata/install/samples/lazyload/slimeboot_lazyload.yaml
+++ b/test/e2e/testdata/install/samples/lazyload/slimeboot_lazyload.yaml
@@ -8,7 +8,7 @@ spec:
   image:
     pullPolicy: Always
     repository: docker.io/slimeio/slime-lazyload
-    tag: v0.2.1
+    tag: v0.2.2
   module:
     - name: lazyload
       enable: true


### PR DESCRIPTION
Fix error name of configmap for leader election, and build new image of lazyload and pluginmanager,  from v0.2.1 to v0.2.2.