### PR TITLE
slime metric reconfiguration

### DIFF
--- a/framework/bootstrap/config.go
+++ b/framework/bootstrap/config.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"io/ioutil"
+	"k8s.io/client-go/dynamic"
 	"os"
 
 	"github.com/gogo/protobuf/jsonpb"
@@ -130,6 +131,7 @@ func readModuleConfig(filePath string) (*bootconfig.Config, []byte, []byte, erro
 type Environment struct {
 	Config    *bootconfig.Config
 	K8SClient *kubernetes.Clientset
+	DynamicClient dynamic.Interface
 	Stop      <-chan struct{}
 }
 

--- a/framework/controllers/context.go
+++ b/framework/controllers/context.go
@@ -7,10 +7,10 @@ package controllers
 
 import "slime.io/slime/framework/util"
 
-// You can query which subsets the Host contains, which is defined in the DestinationRule
+// HostSubsetMapping You can query which subsets the Host contains, which is defined in the DestinationRule
 var HostSubsetMapping *util.SubcribeableMap
 
-// You can query the back-end service of the host, which is defined in the VirtualService
+// HostDestinationMapping You can query the back-end service of the host, which is defined in the VirtualService
 var HostDestinationMapping *util.SubcribeableMap
 
 func init() {

--- a/framework/go.mod
+++ b/framework/go.mod
@@ -4,9 +4,9 @@ go 1.13
 
 require (
 	github.com/ghodss/yaml v1.0.0
-	github.com/golang/protobuf v1.4.2
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
+	github.com/golang/protobuf v1.4.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/onsi/ginkgo v1.11.0
 	github.com/onsi/gomega v1.8.1

--- a/framework/go.sum
+++ b/framework/go.sum
@@ -19,7 +19,9 @@ github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbt
 github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
+github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc h1:cAKDfWh5VpdgMhJosfJnn5/FoN2SRZ4p7fJNX58YPaU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
+github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf h1:qet1QNfXsQxTZqLG4oE62mJzwPIB8+Tee4RNCL9ulrY=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
@@ -471,6 +473,7 @@ google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2
 google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.25.0 h1:Ejskq+SyPohKW+1uil0JJMtmHCgJPJ/qWTxr8qp+R4c=
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
+gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=

--- a/framework/model/metric/config.go
+++ b/framework/model/metric/config.go
@@ -1,0 +1,39 @@
+package metric
+
+import (
+	prometheus "github.com/prometheus/client_golang/api/prometheus/v1"
+	prometheusModel "github.com/prometheus/common/model"
+	"slime.io/slime/framework/model/trigger"
+)
+
+type ProducerConfig struct {
+	EnableWatcherProducer bool
+	WatcherProducerConfig WatcherProducerConfig
+	EnableTickerProducer  bool
+	TickerProducerConfig  TickerProducerConfig
+	StopChan              <-chan struct{}
+}
+
+type WatcherProducerConfig struct {
+	Name                    string
+	NeedUpdateMetricHandler func(event trigger.WatcherEvent) QueryMap
+	MetricChan              chan Metric
+	WatcherTriggerConfig    trigger.WatcherTriggerConfig
+	PrometheusSourceConfig  PrometheusSourceConfig
+}
+
+type TickerProducerConfig struct {
+	Name                    string
+	NeedUpdateMetricHandler func(event trigger.TickerEvent) QueryMap
+	MetricChan              chan Metric
+	TickerTriggerConfig     trigger.TickerTriggerConfig
+	PrometheusSourceConfig  PrometheusSourceConfig
+}
+
+type PrometheusSourceConfig struct {
+	Api       prometheus.API
+	Convertor func(queryValue prometheusModel.Value) map[string]string
+}
+
+type AccessLogSourceConfig struct {
+}

--- a/framework/model/metric/model.go
+++ b/framework/model/metric/model.go
@@ -1,0 +1,15 @@
+package metric
+
+type QueryMap map[string][]Handler
+
+type Handler struct {
+	Name  string
+	Query string
+}
+
+type Metric map[string][]Result
+
+type Result struct {
+	Name  string
+	Value map[string]string
+}

--- a/framework/model/metric/producer.go
+++ b/framework/model/metric/producer.go
@@ -1,0 +1,37 @@
+package metric
+
+import (
+	"github.com/prometheus/common/log"
+)
+
+func NewProducer(config *ProducerConfig) {
+
+	var wp *WatcherProducer
+	var tp *TickerProducer
+
+	if config.EnableWatcherProducer {
+		wp = NewWatcherProducer(config.WatcherProducerConfig)
+		wp.Start()
+		go wp.HandleWatcherEvent()
+	}
+
+	if config.EnableTickerProducer {
+		tp = NewTickerProducer(config.TickerProducerConfig)
+		tp.Start()
+		go tp.HandleTickerEvent()
+	}
+
+	// stop producers
+	go func() {
+		<-config.StopChan
+		if config.EnableWatcherProducer {
+			wp.Stop()
+		}
+		if config.EnableTickerProducer {
+			tp.Stop()
+		}
+		log.Infof("all producers stopped")
+		return
+	}()
+
+}

--- a/framework/model/metric/prometheus_source.go
+++ b/framework/model/metric/prometheus_source.go
@@ -1,0 +1,88 @@
+package metric
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	prometheus "github.com/prometheus/client_golang/api/prometheus/v1"
+	prometheusModel "github.com/prometheus/common/model"
+	log "github.com/sirupsen/logrus"
+	"strings"
+	"time"
+)
+
+type PrometheusSource struct {
+	api       prometheus.API
+	convertor func(queryValue prometheusModel.Value) map[string]string
+}
+
+func NewPrometheusSource(config PrometheusSourceConfig) *PrometheusSource {
+	ps := &PrometheusSource{
+		api:       config.Api,
+		convertor: defaultConvertor,
+	}
+	if config.Convertor != nil {
+		ps.convertor = config.Convertor
+	}
+	return ps
+}
+
+func (ps *PrometheusSource) QueryMetric(queryMap QueryMap) (Metric, error) {
+	log := log.WithField("reporter", "PrometheusSource").WithField("function", "QueryMetric")
+
+	metric := make(map[string][]Result)
+
+	for meta, handlers := range queryMap {
+		if len(handlers) == 0 {
+			continue
+		}
+
+		for _, handler := range handlers {
+			queryValue, w, e := ps.api.Query(context.Background(), handler.Query, time.Now())
+			if e != nil {
+				log.Debugf("failed get metric from prometheus, name: %s, query: %s, error: %+v", handler.Name, handler.Query, e)
+				return nil, errors.New(fmt.Sprintf("failed to get metric from prometheus, error: %+v", e))
+			} else if w != nil {
+				log.Debugf("failed get metric from prometheus, name: %s, query: %s, warning: %s", handler.Name, handler.Query, strings.Join(w, ";"))
+				return nil, errors.New(fmt.Sprintf("failed to get metric from prometheus, warning: %s", strings.Join(w, ";")))
+			}
+			result := Result{
+				Name:  handler.Name,
+				Value: ps.convertor(queryValue),
+			}
+			metric[meta] = append(metric[meta], result)
+		}
+
+	}
+	log.Debugf("successfully get metric from prometheus")
+	return metric, nil
+}
+
+func defaultConvertor(qv prometheusModel.Value) map[string]string {
+	result := make(map[string]string)
+
+	switch qv.Type() {
+	case prometheusModel.ValScalar:
+		scalar := qv.(*prometheusModel.Scalar)
+		result[scalar.Value.String()] = scalar.Timestamp.String()
+	case prometheusModel.ValVector:
+		vector := qv.(prometheusModel.Vector)
+		for _, vx := range vector {
+			result[vx.Metric.String()] = vx.Value.String()
+		}
+	case prometheusModel.ValMatrix:
+		matrix := qv.(prometheusModel.Matrix)
+		for _, sampleStream := range matrix {
+			v := ""
+			for _, sp := range sampleStream.Values {
+				v = v + sp.String()
+			}
+			result[sampleStream.Metric.String()] = v
+		}
+	case prometheusModel.ValString:
+		str := qv.(*prometheusModel.String)
+		result[str.Value] = str.Timestamp.String()
+	}
+
+	return result
+}

--- a/framework/model/metric/ticker_producer.go
+++ b/framework/model/metric/ticker_producer.go
@@ -1,0 +1,68 @@
+package metric
+
+import (
+	log "github.com/sirupsen/logrus"
+	"slime.io/slime/framework/model/trigger"
+)
+
+type TickerProducer struct {
+	name                    string
+	needUpdateMetricHandler func(event trigger.TickerEvent) QueryMap
+	tickerTrigger           *trigger.TickerTrigger
+	prometheusSource        *PrometheusSource
+	MetricChan              chan Metric
+	StopChan                chan struct{}
+}
+
+func NewTickerProducer(config TickerProducerConfig) *TickerProducer {
+	return &TickerProducer{
+		name:                    config.Name,
+		needUpdateMetricHandler: config.NeedUpdateMetricHandler,
+		tickerTrigger:           trigger.NewTickerTrigger(config.TickerTriggerConfig),
+		prometheusSource:        NewPrometheusSource(config.PrometheusSourceConfig),
+		MetricChan:              config.MetricChan,
+		StopChan:                make(chan struct{}),
+	}
+}
+
+func (p *TickerProducer) HandleTickerEvent() {
+	log := log.WithField("reporter", "TickerProducer").WithField("function", "HandleTriggerEvent")
+	for {
+		select {
+		case <-p.StopChan:
+			log.Infof("ticker producer exited")
+			return
+		// handle ticker event
+		case event, ok := <-p.tickerTrigger.EventChan():
+			if !ok {
+				log.Warningf("ticker event channel closed, break process loop")
+				return
+			}
+
+			// reconciler callback
+			queryMap := p.needUpdateMetricHandler(event)
+			if queryMap == nil {
+				continue
+			}
+
+			// get metric material
+			metric, err := p.prometheusSource.QueryMetric(queryMap)
+			if err != nil {
+				log.Errorf("%v", err)
+				continue
+			}
+
+			// produce material event
+			p.MetricChan <- metric
+		}
+	}
+}
+
+func (p *TickerProducer) Start() {
+	p.tickerTrigger.Start()
+}
+
+func (p *TickerProducer) Stop() {
+	p.tickerTrigger.Stop()
+	p.StopChan <- struct{}{}
+}

--- a/framework/model/metric/watcher_producer.go
+++ b/framework/model/metric/watcher_producer.go
@@ -1,0 +1,69 @@
+package metric
+
+import (
+	log "github.com/sirupsen/logrus"
+	"slime.io/slime/framework/model/trigger"
+)
+
+type WatcherProducer struct {
+	name                    string
+	needUpdateMetricHandler func(event trigger.WatcherEvent) QueryMap
+	watcherTrigger          *trigger.WatcherTrigger
+	prometheusSource        *PrometheusSource
+	MetricChan              chan Metric
+	StopChan                chan struct{}
+}
+
+func NewWatcherProducer(config WatcherProducerConfig) *WatcherProducer {
+	return &WatcherProducer{
+		name:                    config.Name,
+		needUpdateMetricHandler: config.NeedUpdateMetricHandler,
+		watcherTrigger:          trigger.NewWatcherTrigger(config.WatcherTriggerConfig),
+		prometheusSource:        NewPrometheusSource(config.PrometheusSourceConfig),
+		MetricChan:              config.MetricChan,
+		StopChan:                make(chan struct{}),
+	}
+}
+
+func (p *WatcherProducer) HandleWatcherEvent() {
+	log := log.WithField("reporter", "WatcherProvider").WithField("function", "HandleTriggerEvent")
+	for {
+		select {
+		case <-p.StopChan:
+			log.Infof("watcher producer exited")
+			return
+		// handle watcher event
+		case event, ok := <-p.watcherTrigger.EventChan():
+			if !ok {
+				log.Warningf("watcher event channel closed, break process loop")
+				return
+			}
+			log.Debugf("got watcher trigger event")
+			// reconciler callback
+			queryMap := p.needUpdateMetricHandler(event)
+			if queryMap == nil {
+				log.Debugf("queryMap is nil, finish")
+				continue
+			}
+
+			// get metric material
+			metric, err := p.prometheusSource.QueryMetric(queryMap)
+			if err != nil {
+				log.Errorf("%v", err)
+				continue
+			}
+
+			// produce material event
+			p.MetricChan <- metric
+		}
+	}
+}
+
+func (p *WatcherProducer) Start() {
+	p.watcherTrigger.Start()
+}
+
+func (p *WatcherProducer) Stop() {
+	p.watcherTrigger.Stop()
+	p.StopChan <- struct{}{}
+}

--- a/framework/model/trigger/ticker_trigger.go
+++ b/framework/model/trigger/ticker_trigger.go
@@ -1,0 +1,71 @@
+package trigger
+
+import (
+	log "github.com/sirupsen/logrus"
+	"time"
+)
+
+type TickerTrigger struct {
+	durations    []time.Duration
+	durationsMap map[time.Duration]chan struct{}
+	eventChan    chan TickerEvent
+}
+
+type TickerEvent struct {
+	Duration time.Duration
+}
+
+type TickerTriggerConfig struct {
+	Durations []time.Duration
+	EventChan chan TickerEvent
+}
+
+func NewTickerTrigger(config TickerTriggerConfig) *TickerTrigger {
+	return &TickerTrigger{
+		durations: config.Durations,
+		eventChan: config.EventChan,
+	}
+}
+
+func (t *TickerTrigger) Start() {
+	log := log.WithField("reporter", "TickerTrigger").WithField("function", "Start")
+
+	t.durationsMap = make(map[time.Duration]chan struct{})
+
+	for _, duration := range t.durations {
+		t.durationsMap[duration] = make(chan struct{})
+		log.Infof("add timer %s to metric trigger", duration.String())
+	}
+
+	for duration, channel := range t.durationsMap {
+		go func(du time.Duration, ch chan struct{}) {
+			ticker := time.NewTicker(du)
+			for {
+				select {
+				case _, ok := <-ch:
+					if !ok {
+						log.Debugf("stop a timer")
+						return
+					}
+				case <-ticker.C:
+					log.Debugf("got timer event: duration %v", du)
+					event := TickerEvent{
+						Duration: du,
+					}
+					t.eventChan <- event
+					//log.Debugf("sent timer event to controller: duration %s", timer.String())
+				}
+			}
+		}(duration, channel)
+	}
+}
+
+func (t *TickerTrigger) Stop() {
+	for _, ch := range t.durationsMap {
+		close(ch)
+	}
+}
+
+func (t *TickerTrigger) EventChan() <-chan TickerEvent {
+	return t.eventChan
+}

--- a/framework/model/trigger/watcher_trigger.go
+++ b/framework/model/trigger/watcher_trigger.go
@@ -1,0 +1,109 @@
+package trigger
+
+import (
+	"context"
+	log "github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/tools/cache"
+	"slime.io/slime/framework/util"
+)
+
+type WatcherTrigger struct {
+	kinds         []schema.GroupVersionKind
+	dynamicClient dynamic.Interface
+	watchersMap   map[watch.Interface]chan struct{}
+	eventChan     chan WatcherEvent
+}
+
+type WatcherEvent struct {
+	GVK schema.GroupVersionKind
+	NN  types.NamespacedName
+}
+
+type WatcherTriggerConfig struct {
+	Kinds         []schema.GroupVersionKind
+	DynamicClient dynamic.Interface
+	EventChan     chan WatcherEvent
+}
+
+func NewWatcherTrigger(config WatcherTriggerConfig) *WatcherTrigger {
+	return &WatcherTrigger{
+		kinds:         config.Kinds,
+		dynamicClient: config.DynamicClient,
+		eventChan:     config.EventChan,
+	}
+}
+
+func (t *WatcherTrigger) Start() {
+	log := log.WithField("reporter", "WatcherTrigger").WithField("function", "Start")
+
+	t.watchersMap = make(map[watch.Interface]chan struct{})
+
+	for _, gvk := range t.kinds {
+		gvr, _ := meta.UnsafeGuessKindToResource(gvk)
+		dc := t.dynamicClient
+		lw := &cache.ListWatch{
+			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+				return dc.Resource(gvr).List(options)
+			},
+			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+				return dc.Resource(gvr).Watch(options)
+			},
+		}
+		watcher := util.ListWatcher(context.Background(), lw)
+		t.watchersMap[watcher] = make(chan struct{})
+		log.Infof("add watcher %s to watcher trigger", gvr.String())
+	}
+
+	for wat, channel := range t.watchersMap {
+		go func(w watch.Interface, ch chan struct{}) {
+			for {
+				select {
+				case _, ok := <-ch:
+					if !ok {
+						log.Debugf("stop a watcher")
+						return
+					}
+				case e, ok := <-w.ResultChan():
+					log.Debugf("got watcher event: type %v, kind %v", e.Type, e.Object.GetObjectKind().GroupVersionKind())
+					if !ok {
+						log.Warningf("a result chan of watcher is closed, break process loop")
+						return
+					}
+					object, ok := e.Object.(*unstructured.Unstructured)
+					if !ok {
+						log.Errorf("invalid type of object in watcher event")
+						continue
+					}
+					event := WatcherEvent{
+						GVK: e.Object.GetObjectKind().GroupVersionKind(),
+						NN: types.NamespacedName{
+							Name:      object.GetName(),
+							Namespace: object.GetNamespace(),
+						},
+					}
+					t.eventChan <- event
+					//log.Debugf("sent watcher event to controller: type %s, kind %s", e.Type, e.Object.GetObjectKind().GroupVersionKind().String())
+				}
+			}
+		}(wat, channel)
+	}
+
+}
+
+func (t *WatcherTrigger) Stop() {
+	for _, ch := range t.watchersMap {
+		close(ch)
+	}
+}
+
+func (t *WatcherTrigger) EventChan() <-chan WatcherEvent {
+	return t.eventChan
+}


### PR DESCRIPTION
Provide prometheus source now and accesslog source later.
Provide k8s gvk watcher trigger and crontab kind ticker trigger.
Provide metric producer to send metric to reconciler inside module. Each producer contains a trigger and source. Provide 2 kinds of producer now:
- watcher producer: watcher trigger + prometheus source
- ticker producer: ticker trigger + prometheus source

Provide accesslog producer later.

The source module will handle QueryMap kind data (map[string][]Handler), and return Metric kind data (map[string][]Result). All sources module will obey the rule. 

![slime-metric-v2-architecture](https://user-images.githubusercontent.com/22366230/141734313-9994c209-77ec-45b6-86e0-1486cc2a171f.png)
