### PR TITLE
new metric source 

### DIFF
--- a/boot/helm-charts/slimeboot/templates/cluster-globalsidecar.yaml
+++ b/boot/helm-charts/slimeboot/templates/cluster-globalsidecar.yaml
@@ -91,6 +91,20 @@ spec:
             - --discoveryAddress
             - istio-pilot.{{ $.Values.namespace }}:15010
           env:
+            {{- range $.Values.module }}
+              {{- if .fence }}
+              {{- if .global }}
+              {{- if .global.misc }}
+              {{- if .global.misc.metric_source_type }}
+              {{- if (eq .global.misc.metric_source_type "accesslog") }}
+              - name: ISTIO_BOOTSTRAP_OVERRIDE
+                value: /etc/istio/custom-bootstrap/custom_bootstrap.json
+              {{- end }}
+              {{- end }}
+              {{- end }}
+              {{- end }}
+              {{- end }}
+              {{- end }}
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -165,6 +179,20 @@ spec:
             - mountPath: /etc/certs
               name: istio-certs
               readOnly: true
+            {{- range $.Values.module }}
+            {{- if .fence }}
+            {{- if .global }}
+            {{- if .global.misc }}
+            {{- if .global.misc.metric_source_type }}
+            {{- if (eq .global.misc.metric_source_type "accesslog") }}
+            - mountPath: /etc/istio/custom-bootstrap
+              name: custom-bootstrap-volume
+            {{- end }}
+            {{- end }}
+            {{- end }}
+            {{- end }}
+            {{- end }}
+            {{- end }}
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler
@@ -177,6 +205,22 @@ spec:
             defaultMode: 420
             optional: true
             secretName: istio.global-sidecar
+        {{- range $.Values.module }}
+        {{- if .fence }}
+        {{- if .global }}
+        {{- if .global.misc }}
+        {{- if .global.misc.metric_source_type }}
+        {{- if (eq .global.misc.metric_source_type "accesslog") }}
+        - name: custom-bootstrap-volume
+          configMap:
+            defaultMode: 420
+            name: lazyload-accesslog-source
+        {{- end }}
+        {{- end }}
+        {{- end }}
+        {{- end }}
+        {{- end }}
+        {{- end }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -263,7 +307,99 @@ spec:
     {{- end }}
     {{- end }}
     {{- end }}
-
+---
+{{- range $.Values.module }}
+  {{- if .fence }}
+  {{- if .global }}
+  {{- if .global.misc }}
+  {{- if .global.misc.metric_source_type }}
+  {{- if (eq .global.misc.metric_source_type "accesslog") }}
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: global-sidecar-accesslog
+  namespace: {{ $.Values.istioNamespace }}
+spec:
+  workloadSelector:
+    labels:
+      app: qz-ingress
+  configPatches:
+    - applyTo: NETWORK_FILTER
+      match:
+        #context: GATEWAY
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.filters.network.http_connection_manager"
+      patch:
+        operation: MERGE
+        value:
+          typed_config:
+            "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager"
+            access_log:
+              - name: envoy.access_loggers.http_grpc
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.access_loggers.grpc.v3.HttpGrpcAccessLogConfig
+                  common_config:
+                    log_name: http_envoy_accesslog
+                    transport_api_version: "V3"
+                    grpc_service:
+                      envoy_grpc:
+                        #cluster_name: outbound|{{$.Values.service.logSourcePort}}||{{$.Values.name}}.{{$.Values.namespace}}.svc.cluster.local
+                        cluster_name: lazyload-accesslog-source
+  {{- end }}
+  {{- end }}
+  {{- end }}
+  {{- end }}
+  {{- end }}
+  {{- end }}
+---
+{{- range $.Values.module }}
+  {{- if .fence }}
+  {{- if .global }}
+  {{- if .global.misc }}
+  {{- if .global.misc.metric_source_type }}
+  {{- if (eq .global.misc.metric_source_type "accesslog") }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: lazyload-accesslog-source
+  namespace: {{ $.Values.istioNamespace }}
+data:
+  custom_bootstrap.json: |
+    {
+      "static_resources": {
+        "clusters": [{
+          "name": "lazyload-accesslog-source",
+          "type": "STRICT_DNS",
+          "connect_timeout": "5s",
+          "http2_protocol_options": {},
+          "dns_lookup_family": "V4_ONLY",
+          "load_assignment": {
+            "cluster_name": "lazyload-accesslog-source",
+            "endpoints": [{
+              "lb_endpoints": [{
+                "endpoint": {
+                  "address": {
+                    "socket_address": {
+                      "address": "{{.name}}.{{$.Values.namespace}}",
+                      "port_value": {{$.Values.service.logSourcePort}}
+                    }
+                  }
+                }
+              }]
+            }]
+          },
+          "respect_dns_ttl": true
+        }]
+      }
+    }
+  {{- end }}
+  {{- end }}
+  {{- end }}
+  {{- end }}
+  {{- end }}
+  {{- end }}
   {{ end }}
   {{ end }}
   {{ end }}

--- a/boot/helm-charts/slimeboot/templates/deployment.yaml
+++ b/boot/helm-charts/slimeboot/templates/deployment.yaml
@@ -74,6 +74,10 @@ spec:
               protocol: TCP
             - name: probe-port
               containerPort: {{ $.Values.healthProbePort }}
+              protocol: TCP
+            - name: log-source-port
+              containerPort: {{ $.Values.logSourcePort }}
+              protocol: TCP
           resources:
           {{- toYaml $.Values.resources | nindent 12 }}
           readinessProbe:
@@ -149,6 +153,10 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+    - port: {{ $.Values.service.logSourcePort }}
+      targetPort: log-source-port
+      protocol: TCP
+      name: log-source-port
   selector:
     app: {{.name}}
   {{end}}

--- a/boot/helm-charts/slimeboot/templates/namespaced-globalsidecar.yaml
+++ b/boot/helm-charts/slimeboot/templates/namespaced-globalsidecar.yaml
@@ -92,6 +92,20 @@ spec:
             - --discoveryAddress
             - istio-pilot.{{ $.Values.namespace }}:15010
           env:
+            {{- range $.Values.module }}
+            {{- if .fence }}
+            {{- if .global }}
+            {{- if .global.misc }}
+            {{- if .global.misc.metric_source_type }}
+            {{- if (eq .global.misc.metric_source_type "accesslog") }}
+            - name: ISTIO_BOOTSTRAP_OVERRIDE
+              value: /etc/istio/custom-bootstrap/custom_bootstrap.json
+            {{- end }}
+            {{- end }}
+            {{- end }}
+            {{- end }}
+            {{- end }}
+            {{- end }}
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -166,6 +180,20 @@ spec:
             - mountPath: /etc/certs
               name: istio-certs
               readOnly: true
+            {{- range $.Values.module }}
+            {{- if .fence }}
+            {{- if .global }}
+            {{- if .global.misc }}
+            {{- if .global.misc.metric_source_type }}
+            {{- if (eq .global.misc.metric_source_type "accesslog") }}
+            - mountPath: /etc/istio/custom-bootstrap
+              name: custom-bootstrap-volume
+            {{- end }}
+            {{- end }}
+            {{- end }}
+            {{- end }}
+            {{- end }}
+            {{- end }}
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler
@@ -178,6 +206,22 @@ spec:
             defaultMode: 420
             optional: true
             secretName: istio.global-sidecar
+        {{- range $.Values.module }}
+        {{- if .fence }}
+        {{- if .global }}
+        {{- if .global.misc }}
+        {{- if .global.misc.metric_source_type }}
+        {{- if (eq .global.misc.metric_source_type "accesslog") }}
+        - name: custom-bootstrap-volume
+          configMap:
+            defaultMode: 420
+            name: lazyload-accesslog-source
+        {{- end }}
+        {{- end }}
+        {{- end }}
+        {{- end }}
+        {{- end }}
+        {{- end }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -263,6 +307,99 @@ spec:
   {{- end }}
   {{- end }}
   {{- end }}
+---
+{{- range $.Values.module }}
+{{- if .fence }}
+{{- if .global }}
+{{- if .global.misc }}
+{{- if .global.misc.metric_source_type }}
+{{- if (eq .global.misc.metric_source_type "accesslog") }}
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: global-sidecar-accesslog
+  namespace: {{$istioNamespace}}
+spec:
+  workloadSelector:
+    labels:
+      app: qz-ingress
+  configPatches:
+    - applyTo: NETWORK_FILTER
+      match:
+        #context: GATEWAY
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.filters.network.http_connection_manager"
+      patch:
+        operation: MERGE
+        value:
+          typed_config:
+            "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager"
+            access_log:
+              - name: envoy.access_loggers.http_grpc
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.access_loggers.grpc.v3.HttpGrpcAccessLogConfig
+                  common_config:
+                    log_name: http_envoy_accesslog
+                    transport_api_version: "V3"
+                    grpc_service:
+                      envoy_grpc:
+                        #cluster_name: outbound|{{$.Values.service.logSourcePort}}||{{$.Values.name}}.{{$.Values.namespace}}.svc.cluster.local
+                        cluster_name: lazyload-accesslog-source
+  {{- end }}
+  {{- end }}
+  {{- end }}
+  {{- end }}
+  {{- end }}
+  {{- end }}
+---
+{{- range $.Values.module }}
+{{- if .fence }}
+{{- if .global }}
+{{- if .global.misc }}
+{{- if .global.misc.metric_source_type }}
+{{- if (eq .global.misc.metric_source_type "accesslog") }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: lazyload-accesslog-source
+  namespace: {{$istioNamespace}}
+data:
+  custom_bootstrap.json: |
+    {
+      "static_resources": {
+        "clusters": [{
+          "name": "lazyload-accesslog-source",
+          "type": "STRICT_DNS",
+          "connect_timeout": "5s",
+          "http2_protocol_options": {},
+          "dns_lookup_family": "V4_ONLY",
+          "load_assignment": {
+            "cluster_name": "lazyload-accesslog-source",
+            "endpoints": [{
+              "lb_endpoints": [{
+                "endpoint": {
+                  "address": {
+                    "socket_address": {
+                      "address": "{{.name}}.{{$.Values.namespace}}",
+                      "port_value": {{$.Values.service.logSourcePort}}
+                    }
+                  }
+                }
+              }]
+            }]
+          },
+          "respect_dns_ttl": true
+        }]
+      }
+    }
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
   {{ end }}
   {{ end }}
   {{ end }}

--- a/boot/helm-charts/slimeboot/values.yaml
+++ b/boot/helm-charts/slimeboot/values.yaml
@@ -32,11 +32,6 @@ containerSecurityContext: { }
 # runAsNonRoot: true
 # runAsUser: 1000
 
-service:
-  type: ClusterIP
-  port: 80
-
-
 resources:
   limits:
     cpu: 1
@@ -72,4 +67,12 @@ namespace: mesh-operator
 
 istioNamespace: istio-system
 
+service:
+  type: ClusterIP
+  port: 80
+  logSourcePort: 8082
+
 healthProbePort: 8081
+logSourcePort: 8082
+metricSourceTypeDefault: prometheus
+metricSourceTypeAccesslog: accesslog

--- a/framework/bootstrap/config.go
+++ b/framework/bootstrap/config.go
@@ -34,6 +34,8 @@ var defaultModuleConfig = &bootconfig.Config{
 			"aux-addr":               ":8081",
 			"enable-leader-election": "off",
 			"global-sidecar-mode":    "namespace",
+			"metric_source_type":     "prometheus", // can be prometheus or accesslog
+			"log_source_port":        ":8082",
 		},
 	},
 }
@@ -132,10 +134,10 @@ func readModuleConfig(filePath string) (*bootconfig.Config, []byte, []byte, erro
 }
 
 type Environment struct {
-	Config    *bootconfig.Config
-	K8SClient *kubernetes.Clientset
+	Config        *bootconfig.Config
+	K8SClient     *kubernetes.Clientset
 	DynamicClient dynamic.Interface
-	Stop      <-chan struct{}
+	Stop          <-chan struct{}
 }
 
 func (env *Environment) IstioRev() string {

--- a/framework/go.mod
+++ b/framework/go.mod
@@ -3,6 +3,7 @@ module slime.io/slime/framework
 go 1.13
 
 require (
+	github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad
 	github.com/ghodss/yaml v1.0.0
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
@@ -16,6 +17,7 @@ require (
 	github.com/sirupsen/logrus v1.4.2
 	go.uber.org/zap v1.10.0
 	golang.org/x/net v0.0.0-20201021035429-f5854403a974
+	google.golang.org/grpc v1.35.0
 	gopkg.in/yaml.v2 v2.2.8
 	istio.io/api v0.0.0-20210322145030-ec7ef4cd6eaf
 	k8s.io/api v0.20.2

--- a/framework/go.sum
+++ b/framework/go.sum
@@ -35,6 +35,7 @@ github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnweb
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/chai2010/gettext-go v0.0.0-20160711120539-c6fed771bfd5/go.mod h1:/iP1qXHoty45bqomnu2LM+VVyAEdWN+vtSHGlQgyxbw=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
+github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403 h1:cqQfy1jclcSy/FwLjemeg3SR1yaINm74aQyupQ0Bl8M=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
@@ -69,7 +70,9 @@ github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb
 github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
+github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad h1:EmNYJhPYy0pOFjCx2PrgtaBXmee0iUX9hLlxE1xHOJE=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
+github.com/envoyproxy/protoc-gen-validate v0.1.0 h1:EQciDnbrYxy13PgWoY8AqoxGiPrpgBZ1R8UNe3ddc+A=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.5.0+incompatible h1:ouOWdg56aJriqS0huScTkVXPC5IcNrDCXZ6OoTAWu7M=
@@ -456,12 +459,14 @@ google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19/go.mod h1:VzzqZJRn
 google.golang.org/genproto v0.0.0-20190418145605-e7d98fc518a7/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/genproto v0.0.0-20190502173448-54afdca5d873/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
+google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 h1:+kGHl1aib/qcwaRi1CbqBZ1rk19r85MNUf8HaBghugY=
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.23.1/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=
 google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
+google.golang.org/grpc v1.35.0 h1:TwIQcH3es+MojMVojxxfQ3l3OF2KzlRxML2xZq0kRo8=
 google.golang.org/grpc v1.35.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=

--- a/framework/model/metric/accesslog_convertor.go
+++ b/framework/model/metric/accesslog_convertor.go
@@ -1,0 +1,99 @@
+package metric
+
+import (
+	"errors"
+	data_accesslog "github.com/envoyproxy/go-control-plane/envoy/data/accesslog/v3"
+	log "github.com/sirupsen/logrus"
+	"k8s.io/client-go/kubernetes"
+	"sync"
+)
+
+type AccessLogConvertor struct {
+	name            string                       // handler name
+	cacheResult     map[string]map[string]string // meta -> value
+	cacheResultCopy map[string]map[string]string
+	handler         func(logEntry []*data_accesslog.HTTPAccessLogEntry, clientSet *kubernetes.Clientset) (map[string]map[string]string, error)
+	convertorLock   sync.RWMutex
+	clientSet       *kubernetes.Clientset
+}
+
+func NewAccessLogConvertor(config AccessLogConvertorConfig) *AccessLogConvertor {
+	return &AccessLogConvertor{
+		name:            config.Name,
+		clientSet:       config.ClientSet,
+		handler:         config.Handler,
+		cacheResult:     make(map[string]map[string]string),
+		cacheResultCopy: make(map[string]map[string]string),
+	}
+}
+
+func (alc *AccessLogConvertor) Name() string {
+	return alc.name
+}
+
+func (alc *AccessLogConvertor) CacheResultCopy() map[string]map[string]string {
+	alc.convertorLock.RLock()
+	defer alc.convertorLock.RUnlock()
+
+	return alc.cacheResultCopy
+}
+
+func (alc *AccessLogConvertor) Convert(logEntry []*data_accesslog.HTTPAccessLogEntry) error {
+	log := log.WithField("reporter", "AccessLogConvertor").WithField("function", "Convert")
+	tmpResult, err := alc.handler(logEntry, alc.clientSet)
+	if err != nil {
+		return err
+	}
+
+	alc.convertorLock.Lock()
+	defer alc.convertorLock.Unlock()
+
+	if len(tmpResult) == 0 {
+		return errors.New("tmpResult is nil")
+	}
+
+	needUpdate := false
+	// merge result, copy on write
+	for meta, value := range tmpResult {
+
+		if _, ok := alc.cacheResult[meta]; !ok {
+			// new meta
+			log.Debugf("alc.cacheResult[%s] is not ok, inits", meta)
+			needUpdate = true
+			alc.cacheResult[meta] = value
+			continue
+		}
+
+		// existed meta
+		if updated := valueMerge(alc.cacheResult[meta], value); updated {
+			needUpdate = updated
+		}
+
+	}
+
+	if needUpdate {
+		newCacheResultCopy := make(map[string]map[string]string)
+		for meta, value := range alc.cacheResult {
+			tmpValue := make(map[string]string)
+			for k, v := range value {
+				tmpValue[k] = v
+			}
+			newCacheResultCopy[meta] = tmpValue
+		}
+		alc.cacheResultCopy = newCacheResultCopy
+	}
+
+	return err
+}
+
+func valueMerge(cacheValue, tmpValue map[string]string) bool {
+	needMerge := false
+	for k, v := range tmpValue {
+		// new key
+		if _, ok := cacheValue[k]; !ok {
+			needMerge = true
+			cacheValue[k] = v
+		}
+	}
+	return needMerge
+}

--- a/framework/model/metric/accesslog_source.go
+++ b/framework/model/metric/accesslog_source.go
@@ -1,0 +1,99 @@
+package metric
+
+import (
+	"fmt"
+	service_accesslog "github.com/envoyproxy/go-control-plane/envoy/service/accesslog/v3"
+	log "github.com/sirupsen/logrus"
+	"google.golang.org/grpc"
+	"net"
+)
+
+type AccessLogSource struct {
+	servePort  string
+	convertors []*AccessLogConvertor
+}
+
+func NewAccessLogSource(config AccessLogSourceConfig) *AccessLogSource {
+	source := &AccessLogSource{
+		servePort: config.ServePort,
+	}
+	for _, convertorConfig := range config.AccessLogConvertorConfigs {
+		source.convertors = append(source.convertors, NewAccessLogConvertor(convertorConfig))
+	}
+	return source
+}
+
+// StreamAccessLogs accept access log from lazy xds egress gateway
+func (s *AccessLogSource) StreamAccessLogs(logServer service_accesslog.AccessLogService_StreamAccessLogsServer) error {
+	log := log.WithField("reporter", "AccessLogSource").WithField("function", "StreamAccessLogs")
+	for {
+		message, err := logServer.Recv()
+		if err != nil {
+			return err
+		}
+
+		httpLogEntries := message.GetHttpLogs()
+		log.Debugf("got accesslog %s", httpLogEntries.String())
+		if httpLogEntries != nil {
+			for _, convertor := range s.convertors {
+				if err = convertor.Convert(httpLogEntries.LogEntry); err != nil {
+					log.Errorf("convertor [%s] converted error: %+v", convertor.Name(), err)
+				} else {
+					log.Debugf("convertor %s converts successfully", convertor.Name())
+				}
+			}
+		}
+	}
+}
+
+// Start grpc server
+func (s *AccessLogSource) Start() error {
+	log := log.WithField("reporter", "AccessLogSource").WithField("function", "Start")
+	lis, err := net.Listen("tcp", fmt.Sprintf("%s", s.servePort))
+	if err != nil {
+		return err
+	}
+
+	server := grpc.NewServer()
+	service_accesslog.RegisterAccessLogServiceServer(server, s)
+
+	go func() {
+		log.Infof("accesslog grpc server starts on %s", s.servePort)
+		if err = server.Serve(lis); err != nil {
+			log.Errorf("accesslog grpc server error: %+v", err)
+		}
+	}()
+
+	return nil
+}
+
+func (s *AccessLogSource) QueryMetric(queryMap QueryMap) (Metric, error) {
+	log := log.WithField("reporter", "AccessLogSource").WithField("function", "QueryMetric")
+
+	metric := make(map[string][]Result)
+
+	for meta, handlers := range queryMap {
+		if len(handlers) == 0 {
+			continue
+		}
+
+		for _, handler := range handlers {
+			for _, convertor := range s.convertors {
+				if convertor.Name() != handler.Name {
+					continue
+				}
+				result := Result{
+					Name:  handler.Name,
+					Value: convertor.CacheResultCopy()[meta],
+				}
+				metric[meta] = append(metric[meta], result)
+				log.Debugf("add metric from accesslog %+v", result)
+			}
+		}
+
+	}
+
+	log.Debugf("successfully get metric from accesslog")
+	return metric, nil
+
+}

--- a/framework/model/metric/config.go
+++ b/framework/model/metric/config.go
@@ -1,17 +1,22 @@
 package metric
 
 import (
+	data_accesslog "github.com/envoyproxy/go-control-plane/envoy/data/accesslog/v3"
 	prometheus "github.com/prometheus/client_golang/api/prometheus/v1"
 	prometheusModel "github.com/prometheus/common/model"
+	"k8s.io/client-go/kubernetes"
 	"slime.io/slime/framework/model/trigger"
 )
 
 type ProducerConfig struct {
-	EnableWatcherProducer bool
-	WatcherProducerConfig WatcherProducerConfig
-	EnableTickerProducer  bool
-	TickerProducerConfig  TickerProducerConfig
-	StopChan              <-chan struct{}
+	EnablePrometheusSource bool
+	PrometheusSourceConfig PrometheusSourceConfig
+	AccessLogSourceConfig  AccessLogSourceConfig
+	EnableWatcherProducer  bool
+	WatcherProducerConfig  WatcherProducerConfig
+	EnableTickerProducer   bool
+	TickerProducerConfig   TickerProducerConfig
+	StopChan               <-chan struct{}
 }
 
 type WatcherProducerConfig struct {
@@ -19,7 +24,6 @@ type WatcherProducerConfig struct {
 	NeedUpdateMetricHandler func(event trigger.WatcherEvent) QueryMap
 	MetricChan              chan Metric
 	WatcherTriggerConfig    trigger.WatcherTriggerConfig
-	PrometheusSourceConfig  PrometheusSourceConfig
 }
 
 type TickerProducerConfig struct {
@@ -27,7 +31,6 @@ type TickerProducerConfig struct {
 	NeedUpdateMetricHandler func(event trigger.TickerEvent) QueryMap
 	MetricChan              chan Metric
 	TickerTriggerConfig     trigger.TickerTriggerConfig
-	PrometheusSourceConfig  PrometheusSourceConfig
 }
 
 type PrometheusSourceConfig struct {
@@ -36,4 +39,12 @@ type PrometheusSourceConfig struct {
 }
 
 type AccessLogSourceConfig struct {
+	ServePort                 string
+	AccessLogConvertorConfigs []AccessLogConvertorConfig
+}
+
+type AccessLogConvertorConfig struct {
+	Name      string // handler name
+	ClientSet *kubernetes.Clientset
+	Handler   func(logEntry []*data_accesslog.HTTPAccessLogEntry, clientSet *kubernetes.Clientset) (map[string]map[string]string, error)
 }

--- a/framework/model/metric/model.go
+++ b/framework/model/metric/model.go
@@ -13,3 +13,8 @@ type Result struct {
 	Name  string
 	Value map[string]string
 }
+
+type Source interface {
+	QueryMetric(queryMap QueryMap) (Metric, error)
+	Start() error
+}

--- a/framework/model/metric/producer.go
+++ b/framework/model/metric/producer.go
@@ -6,17 +6,25 @@ import (
 
 func NewProducer(config *ProducerConfig) {
 
+	var source Source
 	var wp *WatcherProducer
 	var tp *TickerProducer
 
+	// init source
+	if config.EnablePrometheusSource {
+		source = NewPrometheusSource(config.PrometheusSourceConfig)
+	} else {
+		source = NewAccessLogSource(config.AccessLogSourceConfig)
+	}
+
 	if config.EnableWatcherProducer {
-		wp = NewWatcherProducer(config.WatcherProducerConfig)
+		wp = NewWatcherProducer(config.WatcherProducerConfig, source)
 		wp.Start()
 		go wp.HandleWatcherEvent()
 	}
 
 	if config.EnableTickerProducer {
-		tp = NewTickerProducer(config.TickerProducerConfig)
+		tp = NewTickerProducer(config.TickerProducerConfig, source)
 		tp.Start()
 		go tp.HandleTickerEvent()
 	}

--- a/framework/model/metric/prometheus_source.go
+++ b/framework/model/metric/prometheus_source.go
@@ -27,6 +27,10 @@ func NewPrometheusSource(config PrometheusSourceConfig) *PrometheusSource {
 	return ps
 }
 
+func (ps *PrometheusSource) Start() error {
+	return nil
+}
+
 func (ps *PrometheusSource) QueryMetric(queryMap QueryMap) (Metric, error) {
 	log := log.WithField("reporter", "PrometheusSource").WithField("function", "QueryMetric")
 

--- a/framework/model/trigger/ticker_trigger.go
+++ b/framework/model/trigger/ticker_trigger.go
@@ -22,15 +22,14 @@ type TickerTriggerConfig struct {
 
 func NewTickerTrigger(config TickerTriggerConfig) *TickerTrigger {
 	return &TickerTrigger{
-		durations: config.Durations,
-		eventChan: config.EventChan,
+		durations:    config.Durations,
+		eventChan:    config.EventChan,
+		durationsMap: make(map[time.Duration]chan struct{}),
 	}
 }
 
 func (t *TickerTrigger) Start() {
 	log := log.WithField("reporter", "TickerTrigger").WithField("function", "Start")
-
-	t.durationsMap = make(map[time.Duration]chan struct{})
 
 	for _, duration := range t.durations {
 		t.durationsMap[duration] = make(chan struct{})


### PR DESCRIPTION
1. add accesslog source, which can produce metric from access log grpc server
- Note: Inspired by [aeraki](https://github.com/aeraki-framework/aeraki) accesslog processing approach, for which we would like to express our gratitude.
2. unify prometheus source and access log as metric source
```yaml
type Source interface {
    QueryMetric(queryMap QueryMap) (Metric, error)
    Start() error
}