### PR TITLE
Support for adding custom http handlers in module level

### DIFF
--- a/framework/bootstrap/config.go
+++ b/framework/bootstrap/config.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/kube-openapi/pkg/common"
 	"os"
 
 	"github.com/gogo/protobuf/jsonpb"
@@ -160,10 +161,11 @@ func readModuleConfig(filePath string) (*bootconfig.Config, []byte, []byte, erro
 }
 
 type Environment struct {
-	Config        *bootconfig.Config
-	K8SClient     *kubernetes.Clientset
-	DynamicClient dynamic.Interface
-	Stop          <-chan struct{}
+	Config          *bootconfig.Config
+	K8SClient       *kubernetes.Clientset
+	DynamicClient   dynamic.Interface
+	HttpPathHandler common.PathHandler
+	Stop            <-chan struct{}
 }
 
 func (env *Environment) IstioRev() string {


### PR DESCRIPTION
Example:

Just add custom http handler in function `InitManager` of lazyload as following, then you have a new api interface `/lazyload/xxx`
```go
func (mo *Module) InitManager(mgr manager.Manager, env bootstrap.Environment, cbs module.InitCallbacks) error {

	// register custom api interface
	env.HttpPathHandler.Handle("xxx", livezHandler())

       // ...
       return nil
}

func livezHandler() http.Handler {
	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
		if _, err := w.Write([]byte("Healthy!")); err != nil {
			log.Errorf("livez probe error, %+v", err)
		}
	})
}
