### PR TITLE
Update revision matching logic

### DIFF
--- a/framework/bootstrap/config.go
+++ b/framework/bootstrap/config.go
@@ -184,9 +184,19 @@ func (env *Environment) IstioRev() string {
 	return env.Config.Global.IstioRev
 }
 
+// RevInScope check revision
+// when StrictRev is true, return true if revision equals global.IstioRev
+// when StrictRev is false, return true if revision equals global.IstioRev or revision is empty or global.IstioRev is empty
 func (env *Environment) RevInScope(rev string) bool {
+
 	if env == nil || env.Config == nil || env.Config.Global == nil {
-		return rev == ""
+		return true
 	}
-	return env.Config.Global.IstioRev == rev || (rev == "" && !env.Config.Global.StrictRev)
+
+	if env.Config.Global.StrictRev {
+		return env.Config.Global.IstioRev == rev
+	} else {
+		return env.Config.Global.IstioRev == rev || rev == "" || env.Config.Global.IstioRev == ""
+	}
+
 }

--- a/framework/controllers/destinationrule_controller.go
+++ b/framework/controllers/destinationrule_controller.go
@@ -61,7 +61,10 @@ func (r *DestinationRuleReconciler) Reconcile(req ctrl.Request) (ctrl.Result, er
 		}
 	}
 
-	if !model.LabelMatchIstioRev(instance.Labels, r.Env.IstioRev()) {
+	istioRev := model.IstioRevFromLabel(instance.Labels)
+	if !r.Env.RevInScope(istioRev) {
+		log.Debugf("existing destinationRule %v istiorev %s but out %s, skip ...",
+			req.NamespacedName, istioRev, r.Env.IstioRev())
 		return ctrl.Result{}, nil
 	}
 	log.Infof("get destinationRule, %s", instance.Name)

--- a/framework/controllers/virtualservice_controller.go
+++ b/framework/controllers/virtualservice_controller.go
@@ -66,7 +66,11 @@ func (r *VirtualServiceReconciler) Reconcile(req ctrl.Request) (ctrl.Result, err
 			return reconcile.Result{}, err
 		}
 	}
-	if !model.LabelMatchIstioRev(instance.Labels, r.Env.IstioRev()) {
+
+	istioRev := model.IstioRevFromLabel(instance.Labels)
+	if !r.Env.RevInScope(istioRev) {
+		log.Debugf("existing virtualService %v istiorev %s but out %s, skip ...",
+			req.NamespacedName, istioRev, r.Env.IstioRev())
 		return ctrl.Result{}, nil
 	}
 


### PR DESCRIPTION
1. StrictRev is true, return true if 
- revision equals global.IstioRev
2. StrictRev is false, return true if one of 
- revision equals global.IstioRev
- revision is empty
- global.IstioRev is empty