### PR TITLE
Support for choosing different envoy filter names

### DIFF
--- a/boot/helm-charts/slimeboot/templates/deployment.yaml
+++ b/boot/helm-charts/slimeboot/templates/deployment.yaml
@@ -58,7 +58,19 @@ spec:
           {{- toYaml $.Values.args | nindent 12 }}
           imagePullPolicy: {{ $.Values.image.pullPolicy }}
           env:
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OPERATOR_NAME
+              value: "slime"
+          {{- if $.Values.env }}
           {{- toYaml $.Values.env | nindent 12 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: 80

--- a/boot/helm-charts/slimeboot/values.yaml
+++ b/boot/helm-charts/slimeboot/values.yaml
@@ -7,18 +7,6 @@ replicaCount: 1
 args:
   - --enable-leader-election
 
-env:
-  - name: WATCH_NAMESPACE
-    valueFrom:
-      fieldRef:
-        fieldPath: metadata.namespace
-  - name: POD_NAME
-    valueFrom:
-      fieldRef:
-        fieldPath: metadata.name
-  - name: OPERATOR_NAME
-    value: "slime"
-
 image:
   #repository: docker.io/slimeio/slime
   pullPolicy: Always

--- a/framework/util/const.go
+++ b/framework/util/const.go
@@ -1,15 +1,49 @@
 package util
 
+import (
+	"os"
+)
+
+var (
+	Envoy_Ratelimit             string
+	Envoy_Route                 string
+	Envoy_HttpConnectionManager string
+)
+
+func init() {
+	if os.Getenv("ENVOY_FILTER_NAME_LEGACY") != "" {
+		Envoy_Ratelimit = Envoy_Ratelimit_v1
+		Envoy_Route = Envoy_Route_v1
+		Envoy_HttpConnectionManager = Envoy_HttpConnectionManager_v1
+	} else {
+		Envoy_Ratelimit = Envoy_Ratelimit_v2
+		Envoy_Route = Envoy_Route_v2
+		Envoy_HttpConnectionManager = Envoy_HttpConnectionManager_v2
+	}
+}
+
+// v1
 const (
 	// Plugins
-	Envoy_Ratelimit             = "envoy.ratelimit"
-	Envoy_Cors                  = "envoy.cors"
-	Envoy_FilterHttpWasm        = "envoy.filters.http.wasm"
-	Envoy_WasmV8                = "envoy.wasm.runtime.v8"
-	Envoy_Route                 = "envoy.router"
-	Envoy_HttpConnectionManager = "envoy.http_connection_manager"
-	Envoy_LocalRateLimit        = "envoy.filters.http.local_ratelimit"
-	Netease_LocalFlowControl    = "com.netease.local_flow_control"
+	Envoy_Ratelimit_v1             = "envoy.ratelimit"
+	Envoy_Route_v1                 = "envoy.router"
+	Envoy_HttpConnectionManager_v1 = "envoy.http_connection_manager"
+)
+
+// v2
+const (
+	// Plugins
+	Envoy_Ratelimit_v2             = "envoy.filters.network.ratelimit"
+	Envoy_Route_v2                 = "envoy.filters.http.router"
+	Envoy_HttpConnectionManager_v2 = "envoy.filters.network.http_connection_manager"
+)
+
+const (
+	Envoy_Cors               = "envoy.cors"
+	Envoy_FilterHttpWasm     = "envoy.filters.http.wasm"
+	Envoy_WasmV8             = "envoy.wasm.runtime.v8"
+	Envoy_LocalRateLimit     = "envoy.filters.http.local_ratelimit"
+	Netease_LocalFlowControl = "com.netease.local_flow_control"
 
 	Struct_Wasm_Config        = "config"
 	Struct_Wasm_Name          = "name"


### PR DESCRIPTION
This commit is compatiable for new version envoyfilter through slime env `ENVOY_FILTER_NAME_LEGACY`. Default value is `v2`, can be overwriten through `spec.env`, like this
```yaml
apiVersion: config.netease.com/v1alpha1
kind: SlimeBoot
metadata:
  name: plugin
  namespace: mesh-operator
spec:
  module:
    - name: plugin
      enable: true
  env:
    - name: ENVOY_FILTER_NAME_LEGACY
      value: v1
// ...
```
Support for assigning different values for 3 variables, as below.
- Envoy_Ratelimit: v1 `envoy.ratelimit`, v2 `envoy.filters.network.ratelimit`
- Envoy_Route: v1 `envoy.router`, v2 `envoy.filters.http.router`
- Envoy_HttpConnectionManager: v1 `envoy.http_connection_manager`, v2 `envoy.filters.network.http_connection_manager`