### PR TITLE
Add aux-port on slime service

### DIFF
--- a/boot/helm-charts/slimeboot/templates/deployment.yaml
+++ b/boot/helm-charts/slimeboot/templates/deployment.yaml
@@ -75,8 +75,8 @@ spec:
             - name: http
               containerPort: 80
               protocol: TCP
-            - name: probe-port
-              containerPort: {{ $.Values.healthProbePort }}
+            - name: aux-port
+              containerPort: {{ $.Values.auxiliaryPort }}
               protocol: TCP
             - name: log-source-port
               containerPort: {{ $.Values.logSourcePort }}
@@ -86,14 +86,14 @@ spec:
           readinessProbe:
             httpGet:
               path: "/modules/readyz"
-              port: probe-port
+              port: aux-port
             initialDelaySeconds: 3
             periodSeconds: 5
             failureThreshold: 1
           livenessProbe:
             httpGet:
               path: "/modules/livez"
-              port: probe-port
+              port: aux-port
             initialDelaySeconds: 3
             periodSeconds: 5
             failureThreshold: 2
@@ -162,6 +162,10 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+    - port: {{ $.Values.service.auxiliaryPort }}
+      targetPort: aux-port
+      protocol: TCP
+      name: aux-port
     - port: {{ $.Values.service.logSourcePort }}
       targetPort: log-source-port
       protocol: TCP

--- a/boot/helm-charts/slimeboot/values.yaml
+++ b/boot/helm-charts/slimeboot/values.yaml
@@ -73,9 +73,10 @@ istioNamespace: istio-system
 service:
   type: ClusterIP
   port: 80
+  auxiliaryPort: 8081
   logSourcePort: 8082
 
-healthProbePort: 8081
+auxiliaryPort: 8081
 logSourcePort: 8082
 
 containers:

--- a/doc/en/slime-boot.md
+++ b/doc/en/slime-boot.md
@@ -104,7 +104,8 @@ Used by slimeboot operator templates to create slime module and slime component.
 | affinity                                   | { }                                                          | module                                                      |                                                              |
 | namespace                                  | mesh-operator                                                | module and component(cluster global-sidecar, pilot)         | namespace deployed slime                                     |
 | istioNamespace                             | istio-system                                                 | component(cluster global-sidecar, namespace global-sidecar) | namespace deployed istio                                     |
-| healthProbePort                            | 8081                                                         | module                                                      | If change, need to be the same with the port contained by config.global.misc["aux-addr"] |
+| auxiliaryPort                              | 8081                                                         | module                                                      | If change, need to be the same with the port contained by config.global.misc["aux-addr"] |
+| service.auxiliaryPort                      | 8081                                                         | module                                                      | port of module serviceto provide auxiliary service, equals to auxiliaryPort above |
 | logSourcePort                              | 8082                                                         | module                                                      | grpc port of module deployment to receive accesslog          |
 | service.logSourcePort                      | 8082                                                         | module                                                      | grpc port of module serviceto receive accesslog, equals to logSourcePort above |
 | containers.slime.volumeMounts              | ""                                                           | module                                                      | The local path corresponding to the storage volume when log rotation is enabled |
@@ -151,7 +152,7 @@ metadata:
 spec:
   namespace: slime					#customize the namespace deployed slime, same with config.global.slimeNamespace
   istioNamespace: istio-system		#customize the namespace deployed istio, same with config.global.istioNamespace
-  healthProbePort: 9091				#same with the port contained by config.global.misc["aux-addr"]
+  auxiliaryPort: 9091				#same with the port contained by config.global.misc["aux-addr"]
   image:
     pullPolicy: Always
     repository: docker.io/slimeio/slime-lazyload
@@ -170,7 +171,7 @@ spec:
           klogLevel: 10        
         misc:
           metrics-addr: ":9090"		#customize the address of slime module manager
-          aux-addr: ":9091"			#customize auxiliary http server address, same with spec.healthProbePort
+          aux-addr: ":9091"			#customize auxiliary http server address, same with spec.auxiliaryPort
       metric:
         prometheus:
           address: http://prometheus.istio-system:9090

--- a/doc/zh/slime-boot.md
+++ b/doc/zh/slime-boot.md
@@ -99,7 +99,8 @@ slimeboot operator templates用到的所有默认值介绍，会用来创建slim
 | affinity                                   | { }                                                          | module                                                      |                                                              |
 | namespace                                  | mesh-operator                                                | module and component(cluster global-sidecar, pilot)         | namespace deployed slime                                     |
 | istioNamespace                             | istio-system                                                 | component(cluster global-sidecar, namespace global-sidecar) | namespace deployed istio                                     |
-| healthProbePort                            | 8081                                                         | module                                                      | 如果修改，要和config.global.misc["aux-addr"]包含的端口值一致 |
+| auxiliaryPort                              | 8081                                                         | module                                                      | 如果修改，要和config.global.misc["aux-addr"]包含的端口值一致 |
+| serivce.auxiliaryPort                      | 8081                                                         | module                                                      | module service提供辅助web服务的端口，要与auxiliaryPort保持一致 |
 | logSourcePort                              | 8082                                                         | module                                                      | module deployment接收accesslog的grpc端口                     |
 | service.logSourcePort                      | 8082                                                         | module                                                      | module service接收accesslog的grpc端口，要与logSourcePort保持一致 |
 | containers.slime.volumeMounts              | ""                                                           | module                                                      | 启用日志轮转时，存储卷对应的本地路径                         |
@@ -148,7 +149,7 @@ metadata:
 spec:
   namespace: slime					#自定义slime部署的namespace，和config.global.slimeNamespace一致
   istioNamespace: istio-system		#自定义istio部署的namespace，和config.global.istioNamespace一致
-  healthProbePort: 9091				#和config.global.misc["aux-addr"]包含的端口值一致
+  auxiliaryPort: 9091				#和config.global.misc["aux-addr"]包含的端口值一致
   image:
     pullPolicy: Always
     repository: docker.io/slimeio/slime-lazyload
@@ -167,7 +168,7 @@ spec:
           klogLevel: 10
         misc:
           metrics-addr: ":9090"		#自定义slime module manager监控指标暴露地址
-          aux-addr: ":9091"			#自定义辅助服务器暴露地址，与spec.healthProbePort一致
+          aux-addr: ":9091"			#自定义辅助服务器暴露地址，与spec.auxiliaryPort
       metric:
         prometheus:
           address: http://prometheus.istio-system:9090


### PR DESCRIPTION
`probe-port` was previously only used for health check, so it was not exposed to the slime service. Now the port is also the address of the user-defined interfaces, so it is renamed to `aux-port` and added to the slime service.