### PR TITLE
Fix invalid vs panic and lazyload supports old istio version

### DIFF
--- a/framework/controllers/virtualservice_controller.go
+++ b/framework/controllers/virtualservice_controller.go
@@ -76,7 +76,7 @@ func (r *VirtualServiceReconciler) Reconcile(req ctrl.Request) (ctrl.Result, err
 
 	// 资源更新
 	m := parseDestination(instance)
-	log.Infof("get destination after parse, %+v", m)
+	log.Debugf("get destination after parse, %+v", m)
 	for k, v := range m {
 		HostDestinationMapping.Set(k, v)
 	}
@@ -104,8 +104,9 @@ func parseDestination(instance *networkingistioiov1alpha3.VirtualService) map[st
 				if ds, ok := hr[vsRoute].([]interface{}); ok {
 					for _, d := range ds {
 						if route, ok := d.(map[string]interface{}); ok {
-							destinationHost := route[vsDestination].(map[string]interface{})[vsHost].(string)
-							dhs[destinationHost] = struct{}{}
+							if destinationHost, ok := route[vsDestination].(map[string]interface{})[vsHost].(string); ok {
+								dhs[destinationHost] = struct{}{}
+							}
 						}
 					}
 				}

--- a/staging/src/slime.io/slime/modules/lazyload/charts/templates/cluster-global-sidecar.yaml
+++ b/staging/src/slime.io/slime/modules/lazyload/charts/templates/cluster-global-sidecar.yaml
@@ -87,6 +87,13 @@ spec:
         {{- end }}
         {{- end }}
         {{- end }}
+        {{- if $gs.sidecarInject }}
+        {{- if $gs.sidecarInject.enable }}
+        {{- with $gs.sidecarInject.annotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- end }}
+        {{- end }}
 #        {{- if $f.globalSidecar }}
 #        {{- if $f.globalSidecar.excludeInbounds }}
 #        traffic.sidecar.istio.io/excludeInboundPorts: {{ $f.globalSidecar.excludeInboundPorts }}
@@ -104,6 +111,10 @@ spec:
         {{- end }}
         {{- end }}
     spec:
+      {{- with $.Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: global-sidecar
       containers:
         - name: global-sidecar
@@ -148,7 +159,7 @@ spec:
           resources:
             {{- toYaml $gs.resources | nindent 12 }}
           securityContext:
-            runAsUser: 1000
+            privileged: true
 ---
   {{- if or (not $g) (not $g.misc) (eq (default "prometheus" $g.misc.metricSourceType) "prometheus") }}
 apiVersion: networking.istio.io/v1alpha3
@@ -266,9 +277,15 @@ spec:
           name: 0.0.0.0_{{ . }}
           filterChain:
             filter:
+            {{- if $gs.legacyFilterName }}
+              name: "envoy.http_connection_manager"
+              subFilter:
+                name: "envoy.router"
+            {{- else }}
               name: "envoy.filters.network.http_connection_manager"
               subFilter:
                 name: "envoy.filters.http.router"
+            {{- end }}
       patch:
         operation: INSERT_BEFORE
         value:
@@ -277,6 +294,13 @@ spec:
             "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
             inline_code: |
               -- place holder
+            # compatiable with istio 1.7+
+            source_codes:
+              add.lua:
+                inline_string: |
+                  function envoy_on_request(request_handle)
+                    request_handle:headers():replace("Slime-Source-Ns", os.getenv("POD_NAMESPACE"))
+                  end
     - applyTo: HTTP_ROUTE
       match :
         context: SIDECAR_OUTBOUND
@@ -290,11 +314,7 @@ spec:
           typed_per_filter_config:
             envoy.filters.http.lua:
               "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.LuaPerRoute
-              source_code:
-                inline_string: |
-                  function envoy_on_request(request_handle)
-                    request_handle:headers():replace("Slime-Source-Ns", os.getenv("POD_NAMESPACE"))
-                  end
+              name: add.lua
     - applyTo: VIRTUAL_HOST
       match:
         proxy:
@@ -349,7 +369,11 @@ spec:
         listener:
           filterChain:
             filter:
+            {{- if $gs.legacyFilterName }}
+              name: "envoy.http_connection_manager"
+            {{- else }}
               name: "envoy.filters.network.http_connection_manager"
+            {{- end }}
       patch:
         operation: MERGE
         value:

--- a/staging/src/slime.io/slime/modules/lazyload/charts/templates/namespace-global-sidecar.yaml
+++ b/staging/src/slime.io/slime/modules/lazyload/charts/templates/namespace-global-sidecar.yaml
@@ -88,6 +88,13 @@ spec:
         {{- end }}
         {{- end }}
         {{- end }}
+        {{- if $gs.sidecarInject }}
+        {{- if $gs.sidecarInject.enable }}
+        {{- with $gs.sidecarInject.annotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- end }}
+        {{- end }}
 #        {{- if $f.globalSidecar }}
 #        {{- if $f.globalSidecar.excludeInbounds }}
 #        traffic.sidecar.istio.io/excludeInboundPorts: {{ $f.globalSidecar.excludeInboundPorts }}
@@ -105,6 +112,10 @@ spec:
         {{- end }}
         {{- end }}
     spec:
+      {{- with $.Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: global-sidecar
       containers:
         - name: global-sidecar
@@ -149,7 +160,7 @@ spec:
           resources:
             {{- toYaml $gs.resources | nindent 12 }}
           securityContext:
-            runAsUser: 1000
+            privileged: true
 ---
   {{- if or (not $g) (not $g.misc) (eq (default "prometheus" $g.misc.metricSourceType) "prometheus") }}
 apiVersion: networking.istio.io/v1alpha3
@@ -318,7 +329,11 @@ spec:
         listener:
           filterChain:
             filter:
+            {{- if $gs.legacyFilterName }}
+              name: "envoy.http_connection_manager"
+            {{- else }}
               name: "envoy.filters.network.http_connection_manager"
+            {{- end }}
       patch:
         operation: MERGE
         value:

--- a/staging/src/slime.io/slime/modules/lazyload/controllers/update_resources.go
+++ b/staging/src/slime.io/slime/modules/lazyload/controllers/update_resources.go
@@ -34,12 +34,13 @@ type SlimeBoot struct {
 }
 
 type SlimeBootSpec struct {
-	Modules        []Module   `json:"module" yaml:"module"`
-	Image          *Image     `json:"image" yaml:"image"`
-	Component      *Component `json:"component" yaml:"component"`
-	Namespace      string     `json:"namespace" yaml:"namespace"`
-	IstioNamespace string     `json:"istioNamespace" yaml:"istioNamespace"`
-	Resources      *Resources `json:"resources" yaml:"resources"`
+	Modules          []Module            `json:"module" yaml:"module"`
+	Image            *Image              `json:"image" yaml:"image"`
+	ImagePullSecrets []map[string]string `json:"imagePullSecrets" yaml:"imagePullSecrets"`
+	Component        *Component          `json:"component" yaml:"component"`
+	Namespace        string              `json:"namespace" yaml:"namespace"`
+	IstioNamespace   string              `json:"istioNamespace" yaml:"istioNamespace"`
+	Resources        *Resources          `json:"resources" yaml:"resources"`
 }
 
 type Component struct {
@@ -47,19 +48,21 @@ type Component struct {
 }
 
 type GlobalSidecar struct {
-	Enable        bool           `json:"enable" yaml:"enable"`
-	Image         *Image         `json:"image" yaml:"image"`
-	Port          int            `json:"port" yaml:"port"`
-	ProbePort     int            `json:"probePort" yaml:"probePort"`
-	Replicas      int            `json:"replicas" yaml:"replicas"`
-	Resources     *Resources     `json:"resources" yaml:"resources"`
-	SidecarInject *SidecarInject `json:"sidecarInject" yaml:"sidecarInject"`
+	Enable           bool           `json:"enable" yaml:"enable"`
+	Image            *Image         `json:"image" yaml:"image"`
+	Port             int            `json:"port" yaml:"port"`
+	ProbePort        int            `json:"probePort" yaml:"probePort"`
+	Replicas         int            `json:"replicas" yaml:"replicas"`
+	Resources        *Resources     `json:"resources" yaml:"resources"`
+	SidecarInject    *SidecarInject `json:"sidecarInject" yaml:"sidecarInject"`
+	LegacyFilterName bool           `json:"legacyFilterName" yaml:"legacyFilterName"`
 }
 
 type SidecarInject struct {
-	Enable bool              `json:"enable" yaml:"enable"`
-	Mode   string            `json:"mode" yaml:"mode"`
-	Labels map[string]string `json:"labels" yaml:"labels"`
+	Enable      bool              `json:"enable" yaml:"enable"`
+	Mode        string            `json:"mode" yaml:"mode"`
+	Labels      map[string]string `json:"labels" yaml:"labels"`
+	Annotations map[string]string `json:"annotations" yaml:"annotations"`
 }
 
 type Resources struct {


### PR DESCRIPTION
1.some invalid vs can cause vs controller panic, fix this problem
2.global-sidecar runs in privileged mode
3.global-sidecar supoorts istio version 1.7+ plugin name
4.lua plugin usage changed,due to compatibale with istio 1.7
5.global-sidecar supports customize pod annotations