### PR TITLE
plugin: fix the bug that envoyplugin can't patch to ROOT

### DIFF
--- a/staging/src/slime.io/slime/modules/plugin/controllers/conversion.go
+++ b/staging/src/slime.io/slime/modules/plugin/controllers/conversion.go
@@ -90,6 +90,11 @@ func translateRlsAndCorsToDirectPatch(settings *types.Struct, applyToHTTPRoute b
 
 func translatePluginToDirectPatch(settings *types.Struct, fieldPatchTo string) *istio.EnvoyFilter_Patch {
 	patch := &istio.EnvoyFilter_Patch{}
+
+	if fieldPatchTo == "ROOT" {
+		fieldPatchTo = ""
+	}
+
 	if fieldPatchTo != "" {
 		patch.Value = &types.Struct{
 			Fields: map[string]*types.Value{


### PR DESCRIPTION
in the pr https://github.com/slime-io/plugin/pull/20, envoyplugin support to patch to `ROOT`，but we lost the feature due to commit https://github.com/slime-io/plugin/commit/0addaa94dd9d6c0faffcaff35004f2790833d610. 