### PR TITLE
Plugin: passing labels to envoyfilter

### DIFF
--- a/framework/model/config.go
+++ b/framework/model/config.go
@@ -1,6 +1,15 @@
 package model
 
+import (
+	"os"
+	"regexp"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
 const IstioRevLabel = "istio.io/rev"
+
+var passthroughLabelPattern = regexp.MustCompile(os.Getenv("SLIME_PASS_LBL_REG"))
 
 func IstioRevFromLabel(l map[string]string) string {
 	if l == nil {
@@ -31,4 +40,31 @@ func PatchIstioRevLabel(lbls *map[string]string, rev string) {
 	}
 
 	(*lbls)[IstioRevLabel] = rev
+}
+
+func PassthroughLabels(lbls *map[string]string, from map[string]string) {
+	if passthroughLabelPattern.String() == "" {
+		return
+	}
+	for k, v := range from {
+		if !passthroughLabelPattern.MatchString(k) {
+			continue
+		}
+		if *lbls == nil {
+			*lbls = map[string]string{}
+		}
+		(*lbls)[k] = v
+	}
+}
+
+func PatchObjectMeta(dst, src *metav1.ObjectMeta) {
+	if src == nil {
+		return
+	}
+
+	if dst == nil {
+		*dst = metav1.ObjectMeta{}
+	}
+
+	PassthroughLabels(&dst.Labels, src.Labels)
 }

--- a/staging/src/slime.io/slime/modules/plugin/controllers/envoyplugin_controller.go
+++ b/staging/src/slime.io/slime/modules/plugin/controllers/envoyplugin_controller.go
@@ -79,6 +79,7 @@ func (r *EnvoyPluginReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error)
 			return reconcile.Result{}, nil
 		}
 	}
+	model.PatchObjectMeta(&ef.ObjectMeta, &instance.ObjectMeta)
 	model.PatchIstioRevLabel(&ef.Labels, istioRev)
 
 	found := &v1alpha3.EnvoyFilter{}

--- a/staging/src/slime.io/slime/modules/plugin/controllers/pluginmanager_controller.go
+++ b/staging/src/slime.io/slime/modules/plugin/controllers/pluginmanager_controller.go
@@ -86,6 +86,7 @@ func (r *PluginManagerReconciler) Reconcile(req ctrl.Request) (ctrl.Result, erro
 			return reconcile.Result{}, nil
 		}
 	}
+	model.PatchObjectMeta(&ef.ObjectMeta, &instance.ObjectMeta)
 	model.PatchIstioRevLabel(&ef.Labels, istioRev)
 
 	found := &v1alpha3.EnvoyFilter{}


### PR DESCRIPTION
some scenarios require pass-through of resource metadata, especially for labels, which can be used to indicate that multiple instances of different types of resources belong to the same group.

this pr provide an environment variable interface `SLIME_PASS_LBL_REG` to configure the labels that need to be passed through, using [the regular syntax of the golang standard library](https://github.com/google/re2/wiki/Syntax) to match the labels.

example:

```
# deploy plugin by slime-boot
apiVersion: config.netease.com/v1alpha1
kind: SlimeBoot
metadata:
  name: plugin
  namespace: mesh-operator
spec:
  module:
    - name: plugin
      enable: true
  env:
    - name: SLIME_PASS_LBL_REG
      value: "^need-pass"
// ...
```

and create a `envoyplugin` with labels:

```
apiVersion: microservice.slime.io/v1alpha1
kind: EnvoyPlugin
metadata:
  labels:
    need-pass/a: "passA"
    need-pass/b: "passB"
    not-need-pass/c: "not_passC"
  name: test
spec:
// ...
```

then, a `envoufilter` would be created:

```
apiVersion: networking.istio.io/v1alpha3
kind: EnvoyFilter
metadata:
  labels:
    need-pass/a: passA
    need-pass/b: passB
  name: test
// ...
```