### PR TITLE
Lazyload: ignore services without label selector

### DIFF
--- a/staging/src/slime.io/slime/modules/lazyload/controllers/process.go
+++ b/staging/src/slime.io/slime/modules/lazyload/controllers/process.go
@@ -256,7 +256,9 @@ func (r *ServicefenceReconciler) refreshFenceStatusOfService(ctx context.Context
 	}
 
 	if sf == nil {
-		if svc != nil && r.isServiceFenced(ctx, svc) {
+		// ignore services without label selector
+		if svc != nil && &(svc.Spec) != nil && svc.Spec.Selector != nil &&
+			len(svc.Spec.Selector) > 0 && r.isServiceFenced(ctx, svc) {
 			// add svc -> add sf
 			sf = &lazyloadv1alpha1.ServiceFence{
 				TypeMeta: metav1.TypeMeta{},


### PR DESCRIPTION
Lazyload generates sidecar with empty workloadSelector for service without label selector. This sidecar will match all services in the same namespace, which is not what we want. So ignore these special services now.