### PR TITLE
framework: ignore ep without related svc error

### DIFF
--- a/framework/bootstrap/configcontroller.go
+++ b/framework/bootstrap/configcontroller.go
@@ -260,7 +260,6 @@ func NewConfigController(config *bootconfig.Config, cfg *rest.Config) (ConfigCon
 		case EventUpdate:
 			isCfg := imc.Get(resource.IstioService, string(hostname), cfg.Namespace)
 			if isCfg == nil {
-				log.Errorf("[epsToIstioResHandler] [EventUpdate] failed to get IstioService %s/%s, related endpoint is %s", cfg.Namespace, string(hostname), cfg.Name)
 				return
 			}
 			is := isCfg.Spec.(*model.Service)


### PR DESCRIPTION
Endpoints without related service is common， like kube-system/kube-scheduler.kube-system.svc.cluster.local in k8s, and kube-system/k8s.io-minikube-hostpath in minikube cluster, so ignore these endpoints error log. Otherwise, there will be too many error logs.