### PR TITLE
lazyload: ignore situation when accesslog dest is ip

### DIFF
--- a/staging/src/slime.io/slime/modules/lazyload/controllers/producer.go
+++ b/staging/src/slime.io/slime/modules/lazyload/controllers/producer.go
@@ -5,6 +5,7 @@ import (
 	stderrors "errors"
 	"fmt"
 	watchtools "k8s.io/client-go/tools/watch"
+	"net"
 	"strconv"
 	"strings"
 	"sync"
@@ -359,6 +360,13 @@ func spliceDestinationSvc(entry *data_accesslog.HTTPAccessLogEntry, sourceSvc st
 	// get destination service info from request.authority
 	auth := entry.Request.Authority
 	dest := strings.Split(auth, ":")[0]
+
+	// check if dest is ip
+	if net.ParseIP(dest) != nil {
+		log.Debugf("Accesslog is %s -> %s, in which the destination is not domain, skip", sourceSvc, dest)
+		return ""
+	}
+
 	destParts := strings.Split(dest, ".")
 	switch len(destParts) {
 	case 1:


### PR DESCRIPTION
When destination address in global-sidecar accesslog is ip, we should ignore rather than add ip to servicefence. Lazyload controller will generate a debug log, like `"Accesslog is default/ratings -> 192.168.100.100, in which the destination is not domain, skip"`.