### PR TITLE
limiter: skip not runing pods in average ratelimiter

### DIFF
--- a/staging/src/slime.io/slime/modules/limiter/controllers/producer.go
+++ b/staging/src/slime.io/slime/modules/limiter/controllers/producer.go
@@ -209,6 +209,11 @@ func queryServicePods(c *kubernetes.Clientset, loc types.NamespacedName) ([]v1.P
 			// pod is deleted
 			continue
 		}
+		if item.Status.Phase != v1.PodRunning {
+			// pods not running
+			log.Debugf("pod %s/%s is not running. Status=%v. skip", item.Namespace, item.Name, item.Status.Phase)
+			continue
+		}
 		pods = append(pods, item)
 	}
 	return pods, nil


### PR DESCRIPTION
this pr solve the problem as following

calculating the number of pods for a service, the non-running state pods are not skipped
