### PR TITLE
framework: supports for path redirect on aux server

### DIFF
--- a/framework/bootstrap/config.go
+++ b/framework/bootstrap/config.go
@@ -49,9 +49,11 @@ var defaultModuleConfig = &bootconfig.Config{
 			"logSourcePort":          ":8082",
 			// which label keys of serviceEntry select endpoints
 			// will take effect when serviceEntry does not have workloadSelector field
-			"seLabelSelectorKeys":    "app",
+			"seLabelSelectorKeys": "app",
 			// indicate whether xds config source enable increment push or not
 			"xdsSourceEnableIncPush": "true",
+			// path redirect mapping of aux server, default is null
+			"pathRedirect": "",
 		},
 	},
 }

--- a/framework/model/module/module.go
+++ b/framework/model/module/module.go
@@ -274,7 +274,24 @@ func Main(bundle string, modules []Module) {
 		}
 	}
 
-	go bootstrap.AuxiliaryHttpServerStart(ph, config.Global.Misc["aux-addr"])
+	go func() {
+		auxAddr := config.Global.Misc["aux-addr"]
+
+		// parse pathRedirect param
+		pathRedirects := make(map[string]string)
+		mappings := strings.Split(config.Global.Misc["pathRedirect"], ",")
+		for _, m := range mappings {
+			paths := strings.Split(m, "->")
+			if len(paths) != 2 {
+				log.Errorf("pathRedirect '%s' parse error: ilegal expression", m)
+				continue
+			}
+			redirectPath, path := paths[0], paths[1]
+			pathRedirects[redirectPath] = path
+		}
+
+		bootstrap.AuxiliaryHttpServerStart(ph, auxAddr, pathRedirects)
+	}()
 
 	for _, startup := range startups {
 		startup(ctx)


### PR DESCRIPTION
## Description
In the previous version (see https://github.com/slime-io/slime/pull/134), we can add custom http handlers in module level, like `/plugin/test`, `lazyload/metrics`. The path always begins with the module name. Now we supports path redirect, so path (alias path) can be anything after we defined the module path (redirect path) like before. 
Use param `global.misc.pathRedirect`, which can contain more than one direct rules. The expression is `[alias path1]->[redirect path1],[alias path2]->[redirect path2],...[alias pathN]->[redirect pathN]`

## Usage Example
```yaml
global:
  log:
    logLevel: debug
  misc:
    aux-addr: ":9091"
    pathRedirect: "/pluginz->/plugin/test,/test->/plugin/test"
name: plugin
kind: plugin
```

Suppose plugin has a custom http handler on `/plugin/test`, then we have 2 more handlers, `/pluginz` and `/test`, which return the same response as `/plugin/test`.