### PR TITLE
refactor httpserver pathRedirects and module config support special AnyMessage

### DIFF
--- a/framework/model/module/module.go
+++ b/framework/model/module/module.go
@@ -254,14 +254,19 @@ func Main(bundle string, modules []Module) {
 			} else {
 				// new version: get mod.Config() value from config.general
 				if modCfg.General != nil {
+					rawMsg, ok := modSelfCfg.(*util.AnyMessage)
 					if len(modCfg.General.XXX_unrecognized) > 0 {
-						if err := proto.Unmarshal(modCfg.General.XXX_unrecognized, modSelfCfg); err != nil {
+						if ok {
+							rawMsg.Raw = modCfg.General.XXX_unrecognized
+						} else if err := proto.Unmarshal(modCfg.General.XXX_unrecognized, modSelfCfg); err != nil {
 							log.Errorf("unmarshal for mod %s XXX_unrecognized (%v) met err %v", modCfg.Name, modCfg.General.XXX_unrecognized, err)
 							fatal()
 						}
 					} else if len(modGeneralJson) > 0 {
 						u := jsonpb.Unmarshaler{AllowUnknownFields: true}
-						if err := u.Unmarshal(bytes.NewBuffer(modGeneralJson), modSelfCfg); err != nil {
+						if ok {
+							rawMsg.RawJson = modGeneralJson
+						} else if err := u.Unmarshal(bytes.NewBuffer(modGeneralJson), modSelfCfg); err != nil {
 							log.Errorf("unmarshal for mod %s modGeneralJson (%v) met err %v", modCfg.Name, modGeneralJson, err)
 							fatal()
 						}

--- a/framework/util/util.go
+++ b/framework/util/util.go
@@ -36,3 +36,18 @@ func UnityHost(host string, namespace string) string {
 func Fatal() {
 	os.Exit(1)
 }
+
+type AnyMessage struct {
+	Raw     []byte
+	RawJson []byte
+}
+
+func (a *AnyMessage) Reset() {
+}
+
+func (a *AnyMessage) String() string {
+	return ""
+}
+
+func (a *AnyMessage) ProtoMessage() {
+}


### PR DESCRIPTION
**refactor httpserver pathRedirects**

prev impl only supports add-handle in `module.InitManager` and limits the usage.
This refactor removes the restriction and upper modules can add handle at any time while the `pathRedirects` also works for that.

**module config support special AnyMessage**

In some cases the module may want to parse the raw config data in its own way rather than providing a certian pb type/obj.
So we add a special data type `AnyMessage` to indicates that.

use case:

```go
type Module struct {
	config util.AnyMessage
}

func (m *Module) Config() proto.Message {
	return &m.config
}
```

