### PR TITLE
support empty workloadselector in smartlimiter when gw is true

### DIFF
--- a/staging/src/slime.io/slime/modules/limiter/model/model.go
+++ b/staging/src/slime.io/slime/modules/limiter/model/model.go
@@ -15,9 +15,9 @@ type RateLimitConfig struct {
 }
 
 type Descriptor struct {
-	Key       string     `yaml:"key,omitempty"`
-	Value     string     `yaml:"value,omitempty"`
-	RateLimit *RateLimit `yaml:"rate_limit,omitempty"`
+	Key         string       `yaml:"key,omitempty"`
+	Value       string       `yaml:"value,omitempty"`
+	RateLimit   *RateLimit   `yaml:"rate_limit,omitempty"`
 	Descriptors []Descriptor `yaml:"descriptors,omitempty"`
 }
 


### PR DESCRIPTION
supprt empty workloadSelector, then the envoyfilter will apply to all enovy pods in the {{ .namespace }}

```yaml
apiVersion: microservice.slime.io/v1alpha2
kind: SmartLimiter
metadata:
  name: prod-gateway
  namespace: gateway-v112
spec:
  gateway: true  
  sets:
    _base:
      descriptor:
      - action:
          fill_interval:
            seconds: 60
          quota: "3"
          strategy: single
        condition: "true"
        target:
          direction: outbound
          route:
          - a.test.com:80/r1
  #workloadSelector:
  #  gw_cluster: prod-gateway   
```