### PR TITLE
use istioRev to manage cr's reconcile instead of istioRev and configRev

### DIFF
--- a/framework/bootstrap/config.go
+++ b/framework/bootstrap/config.go
@@ -203,37 +203,22 @@ func (env *Environment) IstioRev() string {
 }
 
 // RevInScope check revision
-// when StrictRev is true, return true if revision in global.IstioRev or global.configRev
-// when StrictRev is false, return true if revision in (global.IstioRev or global.configRev) or revision is empty or global.IstioRev is empty
+// when StrictRev is true, return true if revision in global.IstioRev
+// when StrictRev is false, return true if revision in global.IstioRev or revision is empty or global.IstioRev is empty
 func (env *Environment) RevInScope(rev string) bool {
 
-	if env == nil || env.Config == nil || env.Config.Global == nil {
+	// if IstioRev is "", strictRev is meaningless, we will manage all resource
+	if env == nil || env.Config == nil || env.Config.Global == nil || env.Config.Global.IstioRev == "" {
 		return true
 	}
 
-	configRevs := initConfigRevision(env.Config.Global.IstioRev, env.Config.Global.ConfigRev)
-	revs := strings.Split(configRevs, ",")
+	istioRevs := strings.Split(env.Config.Global.IstioRev, ",")
 
 	if env.Config.Global.StrictRev {
-		return inRevs(rev, revs)
+		return inRevs(rev, istioRevs)
 	} else {
-		return rev == "" || configRevs == "" || inRevs(rev, revs)
+		return rev == "" || inRevs(rev, istioRevs)
 	}
-}
-
-func inRevs(rev string, revs []string) bool {
-	for _, item := range revs {
-		item = strings.Trim(item, " ")
-
-		if item == rev {
-			return true
-		}
-	}
-	return false
-}
-
-func (env *Environment) ConfigRevs() string {
-	return initConfigRevision(env.Config.Global.IstioRev, env.Config.Global.ConfigRev)
 }
 
 // SelfResourceRev
@@ -246,4 +231,15 @@ func (env *Environment) SelfResourceRev() string {
 		return ""
 	}
 	return env.Config.Global.SelfResourceRev
+}
+
+func inRevs(rev string, revs []string) bool {
+	for _, item := range revs {
+		item = strings.Trim(item, " ")
+
+		if item == rev {
+			return true
+		}
+	}
+	return false
 }

--- a/framework/bootstrap/configcontroller.go
+++ b/framework/bootstrap/configcontroller.go
@@ -48,7 +48,7 @@ func NewConfigController(config *bootconfig.Config, cfg *rest.Config) (ConfigCon
 	stopCh := make(chan struct{})
 	var mcs []*monitorController
 
-	configRevision := initConfigRevision(config.Global.IstioRev, config.Global.ConfigRev)
+	configRevision := config.Global.ConfigRev
 	xdsSourceEnableIncPush := config.Global.Misc["xdsSourceEnableIncPush"] == "true"
 
 	// init all monitorControllers
@@ -512,27 +512,4 @@ func startXdsMonitorController(mc *monitorController, configRevision string, xds
 
 	log.Infof("init xds config source [%s] successfully", mc.configSource.Address)
 	return nil
-}
-
-func initConfigRevision(rev, configRev string) string {
-	var (
-		revs []string
-		has  bool
-	)
-
-	if configRev != "" {
-		for _, p := range strings.Split(configRev, ",") {
-			p = strings.Trim(p, " ")
-			if !has && p == rev {
-				has = true
-			}
-
-			revs = append(revs, p)
-		}
-	}
-
-	if !has {
-		revs = append(revs, rev)
-	}
-	return strings.Join(revs, ",")
 }

--- a/staging/src/slime.io/slime/modules/lazyload/controllers/process.go
+++ b/staging/src/slime.io/slime/modules/lazyload/controllers/process.go
@@ -84,7 +84,7 @@ func (r *ServicefenceReconciler) Refresh(req reconcile.Request, value map[string
 	// if rev not in scope, skip
 	if foundRev := model.IstioRevFromLabel(sf.Labels); !r.env.RevInScope(foundRev) {
 		log.Debugf("existing smartlimiter %v istiorev %s but our %s, skip ...",
-			req.NamespacedName, foundRev, r.env.ConfigRevs())
+			req.NamespacedName, foundRev, r.env.IstioRev())
 		return ctrl.Result{}, nil
 	}
 
@@ -93,7 +93,7 @@ func (r *ServicefenceReconciler) Refresh(req reconcile.Request, value map[string
 		return reconcile.Result{}, nil
 	} else if rev := model.IstioRevFromLabel(sf.Labels); !r.env.RevInScope(rev) {
 		log.Infof("existing sf %v istioRev %s but our %s, skip ...",
-			req.NamespacedName, rev, r.env.ConfigRevs())
+			req.NamespacedName, rev, r.env.IstioRev())
 		return reconcile.Result{}, nil
 	}
 
@@ -290,7 +290,7 @@ func (r *ServicefenceReconciler) refreshFenceStatusOfService(ctx context.Context
 	} else if rev := model.IstioRevFromLabel(sf.Labels); !r.env.RevInScope(rev) {
 		// check if svc needs auto fence created
 		log.Errorf("existed fence %v istioRev %s but our rev %s, skip ...",
-			nsName, rev, r.env.ConfigRevs())
+			nsName, rev, r.env.IstioRev())
 	} else if isFenceCreatedByController(sf) && (svc == nil || !r.isServiceFenced(ctx, svc)) {
 		if err := r.Client.Delete(ctx, sf); err != nil {
 			log.Errorf("delete fence %s failed, %+v", nsName, err)

--- a/staging/src/slime.io/slime/modules/limiter/controllers/process.go
+++ b/staging/src/slime.io/slime/modules/limiter/controllers/process.go
@@ -135,7 +135,7 @@ func (r *SmartLimiterReconciler) Refresh(request reconcile.Request, args map[str
 	// if rev not in scope, skip
 	if !r.env.RevInScope(slime_model.IstioRevFromLabel(instance.Labels)) {
 		log.Debugf("existing smartlimiter %v istiorev %s but our %s, skip ...",
-			request.NamespacedName, slime_model.IstioRevFromLabel(instance.Labels), r.env.ConfigRevs())
+			request.NamespacedName, slime_model.IstioRevFromLabel(instance.Labels), r.env.IstioRev())
 		return ctrl.Result{}, nil
 	}
 
@@ -271,7 +271,7 @@ func refreshEnvoyFilter(instance *microservicev1alpha2.SmartLimiter, r *SmartLim
 		}
 	} else if foundRev := slime_model.IstioRevFromLabel(found.Labels); !r.env.RevInScope(foundRev) {
 		log.Debugf("existing envoyfilter %v istioRev %s but our %s, skip ...",
-			loc, foundRev, r.env.ConfigRevs())
+			loc, foundRev, r.env.IstioRev())
 	} else {
 		foundSpec, err := json.Marshal(found.Spec)
 		if err != nil {

--- a/staging/src/slime.io/slime/modules/limiter/controllers/smartlimiter_controller.go
+++ b/staging/src/slime.io/slime/modules/limiter/controllers/smartlimiter_controller.go
@@ -101,7 +101,7 @@ func (r *SmartLimiterReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		log.Infof("%v is added or updated", req)
 		if !r.env.RevInScope(slime_model.IstioRevFromLabel(instance.Labels)) {
 			log.Debugf("existing smartlimiter %v istiorev %s but our %s, skip ...",
-				req.NamespacedName, slime_model.IstioRevFromLabel(instance.Labels), r.env.ConfigRevs())
+				req.NamespacedName, slime_model.IstioRevFromLabel(instance.Labels), r.env.IstioRev())
 			return ctrl.Result{}, nil
 		}
 		r.lastUpdatePolicyLock.RLock()

--- a/staging/src/slime.io/slime/modules/plugin/controllers/envoyplugin_controller.go
+++ b/staging/src/slime.io/slime/modules/plugin/controllers/envoyplugin_controller.go
@@ -102,7 +102,7 @@ func (r *EnvoyPluginReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		}
 	} else if foundRev := model.IstioRevFromLabel(found.Labels); !r.Env.RevInScope(foundRev) {
 		log.Debugf("existed envoyfilter %v istioRev %s but our rev %s, skip updating to %+v",
-			req.NamespacedName, found, r.Env.ConfigRevs(), ef)
+			req.NamespacedName, found, r.Env.IstioRev(), ef)
 	} else {
 		log.Infof("Update a EnvoyFilter in %s:%s", ef.Namespace, ef.Name)
 		ef.ResourceVersion = found.ResourceVersion

--- a/staging/src/slime.io/slime/modules/plugin/controllers/pluginmanager_controller.go
+++ b/staging/src/slime.io/slime/modules/plugin/controllers/pluginmanager_controller.go
@@ -135,7 +135,7 @@ func (r *PluginManagerReconciler) reconcile(ctx context.Context, nn types.Namesp
 		}
 	} else if foundRev := model.IstioRevFromLabel(found.Labels); !r.env.RevInScope(foundRev) {
 		log.Debugf("existing envoyfilter %v istioRev %s but our %s, skip ...",
-			nsName, foundRev, r.env.ConfigRevs())
+			nsName, foundRev, r.env.IstioRev())
 		return reconcile.Result{}, nil
 	} else {
 		log.Infof("Update a EnvoyFilter in %v", nsName)


### PR DESCRIPTION
1. istioRev: determines the scope of management

usage

If a is set, then whatever b is

if istioRev is empty, then whatever strictRev  is true or false, slime will manage the all cr

```yaml
global:
  istioRev: ""
```

if strictRev is true, slime will only manage the cr with labels  `istio.io/rev: istio-17` or `istio.io/rev: istio-112` 
```yaml
global:
  istioRev: istio-17,istio-112
  strictRev: true
```

if strictRev is false, slime will manage the cr with label  `istio.io/rev: istio-17` or `istio.io/rev: istio-112`  or cr without rev label

```yaml
global:
  istioRev: istio-17,istio-112
  strictRev: false
```

if strictRev is false and istioRev is empty, slime will manage the all cr

```yaml
global:
  strictRev: false
```



2. slime will retrive config via configRev instead of  istioRev+configRev

