### PR TITLE
plugin module support leader role switch-over

### DIFF
--- a/staging/src/slime.io/slime/modules/plugin/controllers/controllers.go
+++ b/staging/src/slime.io/slime/modules/plugin/controllers/controllers.go
@@ -1,8 +1,12 @@
 package controllers
 
 import (
+	"k8s.io/apimachinery/pkg/types"
 	frameworkmodel "slime.io/slime/framework/model"
 	"slime.io/slime/modules/plugin/model"
 )
 
-var log = model.ModuleLog.WithField(frameworkmodel.LogFieldKeyPkg, "controllers")
+var (
+	log     = model.ModuleLog.WithField(frameworkmodel.LogFieldKeyPkg, "controllers")
+	emptyNN = types.NamespacedName{}
+)

--- a/staging/src/slime.io/slime/modules/plugin/module/module.go
+++ b/staging/src/slime.io/slime/modules/plugin/module/module.go
@@ -6,10 +6,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
-
 	istionetworkingapi "slime.io/slime/framework/apis/networking/v1alpha3"
-	"slime.io/slime/framework/bootstrap"
 	"slime.io/slime/framework/model/module"
 	pluginapiv1alpha1 "slime.io/slime/modules/plugin/api/v1alpha1"
 	"slime.io/slime/modules/plugin/controllers"
@@ -48,10 +45,12 @@ func (m *Module) Clone() module.Module {
 	return &ret
 }
 
-func (m *Module) InitManager(mgr manager.Manager, env bootstrap.Environment, cbs module.InitCallbacks) error {
+func (m *Module) Setup(opts module.ModuleOptions) error {
 	cfg := &m.config
-
 	_ = cfg // unused until now
+
+	env := opts.Env
+	mgr := opts.Manager
 
 	var err error
 	if err = controllers.NewPluginManagerReconciler(env, mgr.GetClient(), mgr.GetScheme()).SetupWithManager(mgr); err != nil {
@@ -67,9 +66,5 @@ func (m *Module) InitManager(mgr manager.Manager, env bootstrap.Environment, cbs
 		os.Exit(1)
 	}
 
-	return nil
-}
-
-func (m *Module) Setup(opts module.ModuleOptions) error {
 	return nil
 }


### PR DESCRIPTION
# background

The reconcile from the refresh-plugins-affected-by-changed-secret logic is not called by controller runtime and thus it will still works when current instance switches to candidate/standby role and competes with the leader/primary instance.

# solution

Use the ability provided by the framework layer to sense the current instance role and execute this update process only when it is the primary role, while the standby role state only caches the sensed changes and executes a resync the next time (if any) it cuts to the primary use.
