### PR TITLE
slime: support init new module from template

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,3 +85,8 @@ shell:
 		$(IMG)  \
 		bash
 endif
+
+MODULE_NAME?=
+.PHONY: new-module
+new-module:
+	bash bin/gen_module.sh $(MODULE_NAME)

--- a/bin/gen_module.sh
+++ b/bin/gen_module.sh
@@ -3,7 +3,9 @@
 # usage example: bash gen_module.sh my_module
 # get $MPATH/src/my_module
 
-MPATH=${MPATH:-$GOPATH}
+BASEDIR=$(dirname $0)
+TEMPLATE_PATH=${BASEDIR}/../modules/example
+MPATH=$(realpath ${MPATH:-"${BASEDIR}/../staging/src/slime.io/slime/modules"})
 echo "Module path is $MPATH"
 # get module name
 if [[ "$#" -eq 0 ]]; then
@@ -14,56 +16,43 @@ else
   Module_name="${module_name^}"
 fi
 
+
 # check destination directory
-if [ -d "$MPATH/src/$module_name" ]; then
-  read -p "$MPATH/src/$module_name already exists. Delete? (yes/no)" delete
+if [ -d "$MPATH/$module_name" ]; then
+  read -p "$MPATH/$module_name already exists. Delete? (yes/no)" delete
   if [[ "$delete" != "yes" ]]; then
     echo "Exit without actions."
     exit 1
   else
-    echo "Delete old $MPATH/src/$module_name directory."
-    rm -rf "$MPATH/src/$module_name"
+    echo "Delete old $MPATH/$module_name directory."
+    rm -rf "$MPATH/$module_name"
   fi
 fi
 
 # generate files from example
-cp -r "$MPATH/src/slime/modules/example" "$MPATH/src/$module_name"
-cd "$MPATH/src/$module_name"
+cp -r "${TEMPLATE_PATH}" "$MPATH/$module_name"
+cd "$MPATH/$module_name"
 
 function replace_example() {
   sed -i "s/example/$module_name/g" $1
   sed -i "s/Example/$Module_name/g" $1
-  echo "replace $1"
 }
 
-# replace go.mod
-replace_example go.mod
+function rename_file(){
+  src=$1
+  if grep "example" $src;then
+    dst="${src/example/"${module_name}"}"
+    mv $src $dst
+  fi
+}
 
-# replace api
-replace_example api/v1alpha1/config.proto
-cd api/v1alpha1
-GO111MODULE="off" protoc -I=. -I=$GOPATH/src -I=$GOPATH/src/github.com/gogo/protobuf/protobuf --gogo_opt=paths=source_relative --gogo_out=. config.proto
-cd ../..
+for f in $(find . -type f);do
+  replace_example $f
+  rename_file $f
+done
 
-# replace main.go
-replace_example main.go
-
-# replace controllers
-replace_example controllers/example_reconciler.go
-mv controllers/example_reconciler.go "controllers/${module_name}_reconciler.go"
-
-# replace model
-replace_example model/model.go
-
-# replace module
-replace_example module/module.go
-
-# replace install
-replace_example install/slimeboot_example.yaml
-mv install/slimeboot_example.yaml install/slimeboot_${module_name}.yaml
-
-# replace publish.sh
-replace_example publish.sh
-sed -i "s/..\/..\/bin\/publish.sh/..\/slime\/bin\/publish.sh/" publish.sh
+# modify go.mod
+sed -i "/need delete/d" go.mod
+sed -i "/need uncomment/s/\/\/ //" go.mod
 
 echo "module $module_name generates successfully"

--- a/modules/example/install/samples/slimeboot_example.yaml
+++ b/modules/example/install/samples/slimeboot_example.yaml
@@ -1,0 +1,14 @@
+apiVersion: config.netease.com/v1alpha1
+kind: SlimeBoot
+metadata:
+  name: example
+  namespace: mesh-operator
+spec:
+  image:
+    pullPolicy: Always
+    repository: docker.io/slimeio/slime-example
+    tag: latest
+  module:
+    - name: example
+      kind: example
+      enable: true

--- a/modules/example/module/module.go
+++ b/modules/example/module/module.go
@@ -6,12 +6,9 @@ import (
 	"github.com/golang/protobuf/proto"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	istionetworkingapi "slime.io/slime/framework/apis/networking/v1alpha3"
-	"slime.io/slime/framework/bootstrap"
 	"slime.io/slime/framework/model/module"
-	"slime.io/slime/framework/model/pkg/leaderelection"
 	"slime.io/slime/modules/example/api/config"
 	v1alpha1 "slime.io/slime/modules/example/api/v1alpha1"
 	"slime.io/slime/modules/example/controllers"
@@ -50,7 +47,9 @@ func (mo *Module) Clone() module.Module {
 	return &ret
 }
 
-func (mo *Module) InitManager(mgr manager.Manager, env bootstrap.Environment, cbs module.InitCallbacks) error {
+func (mo *Module) Setup(opts module.ModuleOptions) error {
+	env := opts.Env
+	mgr := opts.Manager
 	cfg := &mo.config
 
 	var err error
@@ -61,21 +60,5 @@ func (mo *Module) InitManager(mgr manager.Manager, env bootstrap.Environment, cb
 		os.Exit(1)
 	}
 
-	return nil
-}
-
-func (m *Module) Init(env bootstrap.Environment) error {
-	return nil
-}
-
-func (m *Module) SetupWithInitCallbacks(cbs module.InitCallbacks) error {
-	return nil
-}
-
-func (m *Module) SetupWithManager(mgr manager.Manager) error {
-	return nil
-}
-
-func (m *Module) SetupWithLeaderElection(le leaderelection.LeaderCallbacks) error {
 	return nil
 }


### PR DESCRIPTION
Run `MODULE_NAME=foo make new-module` or `bash bin/gen_module.sh foo` to initialize a new module scaffold. After modifying the api, run `MODULES=foo make generate-module` to regenerate the code.