### PR TITLE
global-sidecar: disable auto shutdown proxy server

### DIFF
--- a/staging/src/slime.io/slime/modules/lazyload/cmd/proxy/main.go
+++ b/staging/src/slime.io/slime/modules/lazyload/cmd/proxy/main.go
@@ -158,12 +158,14 @@ func startListenAndServe(wormholePorts map[int]struct{}) {
 		}
 	}
 
-	for whPort, srv := range servers {
-		if _, exist := wormholePorts[whPort]; !exist {
-			delete(servers, whPort)
-			go shutdownServer(srv)
-		}
-	}
+	// ports will only be automatically increased when auto managing.
+	// more info can be found at: https://github.com/slime-io/slime/pull/157
+	// for whPort, srv := range servers {
+	// 	if _, exist := wormholePorts[whPort]; !exist {
+	// 		delete(servers, whPort)
+	// 		go shutdownServer(srv)
+	// 	}
+	// }
 }
 
 func startServer(srv *http.Server) {


### PR DESCRIPTION
> For security purposes, ports will only be automatically increased when auto managing. 

the proxy server started by global-sidecar should not be turned off due to https://github.com/slime-io/slime/pull/157.