### PR TITLE
build-tools integrates docker(cli) for building and publishing

### DIFF
--- a/docker/Dockerfile.build-tools
+++ b/docker/Dockerfile.build-tools
@@ -1,9 +1,24 @@
-FROM golang:1.16.15-bullseye
+FROM golang:1.17.13-bullseye
 
 WORKDIR /workspaces
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    lsb-release \
+    software-properties-common \
+    jq \
     unzip && \
+    apt-get clean
+
+# install docker
+ENV DOCKER_VERSION=5:23.0.0-1~debian.11~bullseye
+ENV CONTAINERD_VERSION=1.6.16-1
+ADD https://download.docker.com/linux/debian/gpg /etc/apt/keyrings/docker.gpg
+RUN apt-key add /etc/apt/keyrings/docker.gpg && \
+    add-apt-repository "deb [arch=$(dpkg --print-architecture)] https://download.docker.com/linux/debian $(lsb_release -cs) stable"
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    docker-ce="${DOCKER_VERSION}" \
+    docker-ce-cli="${DOCKER_VERSION}" \
+    containerd.io="${CONTAINERD_VERSION}" && \
     apt-get clean
 
 # version of toolchains


### PR DESCRIPTION
In order to use more interfaces directly, we upgrade go-control-plane to v0.11.0, for which the go version needs to be upgraded to 1.17.

specifically we introduce [QueryParameterMatcher in ](https://github.com/envoyproxy/go-control-plane/blob/fd73e3e0fadcc4c69759e862fa3ff48bb92ee633/envoy/config/route/v3/route_components.pb.go#L3631) to support
queryMatch in limiter,


releate pr https://github.com/slime-io/slime/pull/281
