### PR TITLE
framework: add initready and init method

### DIFF
--- a/framework/bootstrap/k8s.go
+++ b/framework/bootstrap/k8s.go
@@ -414,6 +414,7 @@ func startK8sMonitorController(mc *monitorController, cfg *rest.Config, stopCh <
 	seInformerFactory.Start(stopCh)
 	cache.WaitForCacheSync(stopCh, seInformer.HasSynced)
 
+	mc.SetReady()
 	log.Infof("start K8S config source successfully")
 	return nil
 }

--- a/staging/src/slime.io/slime/modules/lazyload/module/module.go
+++ b/staging/src/slime.io/slime/modules/lazyload/module/module.go
@@ -3,13 +3,11 @@ package module
 import (
 	"context"
 	"fmt"
-
 	"github.com/golang/protobuf/proto"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-
 	istioapi "slime.io/slime/framework/apis"
 	basecontroller "slime.io/slime/framework/controllers"
 	"slime.io/slime/framework/model/metric"
@@ -26,15 +24,15 @@ type Module struct {
 	config config.Fence
 }
 
-func (mo *Module) Kind() string {
+func (m *Module) Kind() string {
 	return modmodel.ModuleName
 }
 
-func (mo *Module) Config() proto.Message {
-	return &mo.config
+func (m *Module) Config() proto.Message {
+	return &m.config
 }
 
-func (mo *Module) InitScheme(scheme *runtime.Scheme) error {
+func (m *Module) InitScheme(scheme *runtime.Scheme) error {
 	for _, f := range []func(*runtime.Scheme) error{
 		clientgoscheme.AddToScheme,
 		lazyloadapiv1alpha1.AddToScheme,
@@ -47,15 +45,13 @@ func (mo *Module) InitScheme(scheme *runtime.Scheme) error {
 	return nil
 }
 
-func (mo *Module) Clone() module.Module {
-	ret := *mo
+func (m *Module) Clone() module.Module {
+	ret := *m
 	return &ret
 }
 
 func (m *Module) Setup(opts module.ModuleOptions) error {
-
 	env, mgr := opts.Env, opts.Manager
-
 	pc, err := controllers.NewProducerConfig(env)
 	if err != nil {
 		return fmt.Errorf("unable to create ProducerConfig, %+v", err)
@@ -69,7 +65,6 @@ func (m *Module) Setup(opts module.ModuleOptions) error {
 	sfReconciler.Scheme = mgr.GetScheme()
 
 	opts.InitCbs.AddStartup(func(ctx context.Context) {
-		// start service related cache
 		sfReconciler.StartSvcCache(ctx)
 	})
 

--- a/staging/src/slime.io/slime/modules/limiter/module/module.go
+++ b/staging/src/slime.io/slime/modules/limiter/module/module.go
@@ -55,6 +55,7 @@ func (m *Module) Clone() module.Module {
 	return &ret
 }
 func (m *Module) Setup(opts module.ModuleOptions) error {
+
 	if err := m.init(opts.Env); err != nil {
 		return err
 	}

--- a/staging/src/slime.io/slime/modules/meshregistry/module/module.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/module/module.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-
 	"github.com/golang/protobuf/proto"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"

--- a/staging/src/slime.io/slime/modules/plugin/module/module.go
+++ b/staging/src/slime.io/slime/modules/plugin/module/module.go
@@ -2,7 +2,6 @@ package module
 
 import (
 	"fmt"
-
 	"github.com/golang/protobuf/proto"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"


### PR DESCRIPTION
use InitReady() to indicate whether the framework is ready

```go
type InitReady interface {
	InitReady() bool
        // InitReady() <-chan struct
}

type ConfigController interface {
	viewstore.ViewerStore
	RegisterEventHandler(kind resource.GroupVersionKind, handler func(resource.Config, resource.Config, Event))
	Run(stop <-chan struct{})
	InitReady
}
```

submodule can determine whether ready as following

```go
func (m *Module) Setup(opts module.ModuleOptions) error {
	cbs := opts.InitCbs
	cbs.AddStartup(func(ctx context.Context) {
		go func() {
                        if env.ConfigController != nil {
                                env.WaitReady(env.ConfigController)
                         }

			// Create the server for the discovery service.
			registryServer, err := server.NewServer(&server.Args{
				SlimeEnv:     opts.Env,
				RegistryArgs: regArgs,
			})
			if err != nil {
				log.Errorf("failed to create discovery service: %v", err)
				return
			}

			// Start the server
			if err := registryServer.Run(ctx.Done()); err != nil {
				log.Errorf("failed to start discovery service: %v", err)
				return
			}
		}()
	})
}	
```
