### PR TITLE
meshreg: nacos source support security access

### DIFF
--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/bootstrap/args.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/bootstrap/args.go
@@ -163,6 +163,9 @@ type NacosSourceArgs struct {
 	K8sDomainSuffix bool
 	// need ns in Host
 	NsHost bool
+	// username and password for nacos auth
+	Username string
+	Password string
 }
 
 type McpArgs struct {

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/nacos/source.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/nacos/source.go
@@ -102,7 +102,7 @@ func New(nacoesArgs bootstrap.NacosSourceArgs, nsHost bool, k8sDomainSuffix bool
 		}
 	}
 	if nacoesArgs.Mode == POLLING {
-		source.client = NewClient(nacoesArgs.Address, headers)
+		source.client = NewClient(nacoesArgs.Address, nacoesArgs.Username, nacoesArgs.Password, headers)
 	} else {
 		namingClient, err := newNamingClient(nacoesArgs.Address, nacoesArgs.Namespace, headers)
 		if err != nil {


### PR DESCRIPTION
meshregistry nacos source add new configuration `Username` and `Password` to access nacos server using authentication.

usage:

```
apiVersion: v1
data:
  cfg: |
    bundle:
      modules:
      - name: meshregistry
        kind: meshregistry
    enable: true
  cfg_meshregistry: |
    name: meshregistry
    kind: meshregistry
    enable: true
    mode: BundleItem
    general:
      LEGACY:
        MeshConfigFile: ""
        RevCrds: ""
        Mcp:
          EnableIncPush: false
        NacosSource:
          Enabled: true
          Address:
          - "http://nacos-0.nacos-headless.default:8848"
          - "http://nacos-1.nacos-headless.default:8848"
          - "http://nacos-2.nacos-headless.default:8848"
          Mode: polling
          Username: nacos
          Password: nacos
```