### PR TITLE
nacos source support fetching instances from all namespaces

### DIFF
--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/bootstrap/args.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/bootstrap/args.go
@@ -169,6 +169,8 @@ type NacosSourceArgs struct {
 	// username and password for nacos auth
 	Username string
 	Password string
+	// fetch services from all namespaces, only support Polling mode
+	AllNamespaces bool
 }
 
 type McpArgs struct {

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/nacos/source.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/nacos/source.go
@@ -26,7 +26,6 @@ type Source struct {
 	// nacos client
 	client       Client
 	namingClient naming_client.INamingClient
-	namespace    string
 	group        string
 
 	// common configs
@@ -34,6 +33,9 @@ type Source struct {
 	gatewayModel    bool
 	nsHost          bool
 	k8sDomainSuffix bool
+	allNamespaces   bool
+	namespace       string
+	namespaces      []string
 	svcPort         uint32
 	mode            string
 	delay           time.Duration
@@ -110,7 +112,13 @@ func New(nacoesArgs bootstrap.NacosSourceArgs, nsHost bool, k8sDomainSuffix bool
 		}
 	}
 	if nacoesArgs.Mode == POLLING {
-		s.client = NewClient(nacoesArgs.Address, nacoesArgs.Username, nacoesArgs.Password, headers)
+		s.client = NewClient(nacoesArgs.Address,
+			nacoesArgs.Username,
+			nacoesArgs.Password,
+			nacoesArgs.Namespace,
+			nacoesArgs.Group,
+			nacoesArgs.AllNamespaces,
+			headers)
 	} else {
 		namingClient, err := newNamingClient(nacoesArgs.Address, nacoesArgs.Namespace, headers)
 		if err != nil {


### PR DESCRIPTION
Before we fetch the nacos service only in a specific namespace/group, which can be set in this way:
``` yaml
NacosSource:
  Namespace: public
  Group: DEFAULT_GROUP
```
Now we support fetching the nacos service in all group in all namespaces, which can be set in this way:

``` yaml
NacosSource:
  AllNamespaces: true
```

When "AllNamespaces" is enabled, we merge instances with the same service name from different namespaces and groups into a single ServiceEntry.

We use the API `/nacos/v1/ns/catalog/services` for fetching all services in all groups in a specific namespace. This api, which we found in the nacos 1.4.x console, is not documented in the [nacos openAPI](https://nacos.io/zh-cn/docs/open-api.html) documentation, so we cannot guarantee that this feature is compatible with the latest version of nacos in the community.


