### PR TITLE
meshregistry: nacos source support filtering instance

### DIFF
--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/bootstrap/args.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/bootstrap/args.go
@@ -93,6 +93,9 @@ type SourceArgs struct {
 	// if empty, those endpoints with ns attr will be aggregated into a no-ns service like "foo"
 	DefaultServiceNs string
 	ResourceNs       string
+	// A list of selectors that specify the set of service instances to be processed,
+	// configured in the same way as the k8s label selector.
+	EndpointSelectors []*metav1.LabelSelector
 }
 
 type K8SSourceArgs struct {

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/nacos/conversion.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/nacos/conversion.go
@@ -8,6 +8,7 @@ import (
 
 	networking "istio.io/api/networking/v1alpha3"
 
+	"slime.io/slime/modules/meshregistry/pkg/source"
 	"slime.io/slime/modules/meshregistry/pkg/util"
 )
 
@@ -72,8 +73,11 @@ func convertEndpoints(instances []*instance, patchLabel bool) ([]*networking.Wor
 		Name:     "http",
 	}
 	ports = append(ports, port)
-
+	filter, enableInstanceFilter := instanceFilter.Load().(source.SelectHook)
 	for _, ins := range instances {
+		if enableInstanceFilter && !filter(ins.Metadata) {
+			continue
+		}
 		if !ins.Healthy {
 			continue
 		}
@@ -157,7 +161,11 @@ func convertEndpointsWithNs(instances []*instance, defaultNs string, svcPort uin
 	sort.Slice(instances, func(i, j int) bool {
 		return instances[i].InstanceId < instances[j].InstanceId
 	})
+	filter, enableInstanceFilter := instanceFilter.Load().(source.SelectHook)
 	for _, ins := range instances {
+		if enableInstanceFilter && !filter(ins.Metadata) {
+			continue
+		}
 		if !ins.Healthy {
 			continue
 		}

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/selector.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/selector.go
@@ -1,0 +1,43 @@
+package source
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+type SelectHook func(map[string]string) bool
+
+type ApplyHook func(SelectHook)
+
+// NewSelectHook build a SelectHook by the input LabelSelectors.
+// If the input LabelSelectors is nil, the returned hook always returns TRUE.
+func NewSelectHook(labelSelectors []*metav1.LabelSelector) SelectHook {
+	if len(labelSelectors) == 0 {
+		return func(_ map[string]string) bool { return true }
+	}
+	var selectors []labels.Selector
+	for _, selector := range labelSelectors {
+		ls, err := metav1.LabelSelectorAsSelector(selector)
+		if err != nil {
+			// ignore invalid LabelSelector
+			continue
+		}
+		selectors = append(selectors, ls)
+	}
+	return func(m map[string]string) bool {
+		if len(selectors) == 0 {
+			return true
+		}
+		for _, selector := range selectors {
+			if selector.Matches(labels.Set(m)) {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+// UpdateSelector updates the given selector with the input LabelSelectors.
+func UpdateSelector(labelSelectors []*metav1.LabelSelector, apply ApplyHook) {
+	apply(NewSelectHook(labelSelectors))
+}


### PR DESCRIPTION
we get all instances registered in the registry, but in some cases need to filter some instances by its metadata, use the LabelSelector to achieve this.

We have introduced a new configuration item Selectors in the general configuration of source，which is a list of selectors that specify the set of service instances to be processed, configured in the same way as the [k8s labelselector](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors).

e.g. filter instances with  `env=dev` in metadata

``` yaml
NacosSource:
  Enabled: true
  Address:
  - "http://127.0.0.1:8848"
  Mode: polling
  EndpointSelectors:
  - MatchExpressions:
    - Key: env
      Operator: NotIn
      Values:
      - "dev"
```

NOTE: only support **Nacos** registry now.
