### PR TITLE
meshregistry: split api dubboCallModel and support param `app`

### DIFF
--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/server/processing.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/server/processing.go
@@ -157,6 +157,7 @@ func (p *Processing) Start() (err error) {
 		p.httpServer.HandleFunc(zookeeper.ZkSimplePath, simpleHttpHandle)
 		if zkSrc, ok := zookeeperSrc.(*zookeeper.Source); ok {
 			p.httpServer.HandleFunc(zookeeper.DubboCallModelPath, zkSrc.HandleDubboCallModel)
+			p.httpServer.HandleFunc(zookeeper.SidecarDubboCallModelPath, zkSrc.HandleSidecarDubboCallModel)
 		}
 		p.httpServer.SourceRegistry(zookeeper.ZK)
 		if srcArgs.WaitTime > 0 {

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/zookeeper/source.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/zookeeper/source.go
@@ -30,13 +30,14 @@ import (
 var scope = log.RegisterScope("zk", "zk debugging", 0)
 
 const (
-	ZK                 = "zk"
-	ZkPath             = "/zk"
-	ZkSimplePath       = "/zks"
-	DubboCallModelPath = "/dubboCallModel"
-	ConsumerNode       = "consumers"
-	ProviderNode       = "providers"
-	Polling            = "polling"
+	ZK                        = "zk"
+	ZkPath                    = "/zk"
+	ZkSimplePath              = "/zks"
+	DubboCallModelPath        = "/dubboCallModel"
+	SidecarDubboCallModelPath = "/sidecarDubboCallModel"
+	ConsumerNode              = "consumers"
+	ProviderNode              = "providers"
+	Polling                   = "polling"
 
 	AttachmentDubboCallModel = "ATTACHEMT_DUBBO_CALL_MODEL"
 )
@@ -61,7 +62,7 @@ type Source struct {
 	cache                cmap.ConcurrentMap
 	pollingCache         cmap.ConcurrentMap
 	sidecarCache         map[resource.FullName]SidecarWithMeta
-	dubboCallModels      map[string]DubboCallModel
+	dubboCallModels      map[string]DubboCallModel // can only be replaced rather than being modified
 	seDubboCallModels    map[resource.FullName]map[string]DubboCallModel
 	changedApps          map[string]struct{}
 	appSidecarUpdateTime map[string]time.Time


### PR DESCRIPTION
1. `/dubboCallModel` -> new `/dubboCallModel` with `provideservices` field fulfilled and `/sidecarDubboCallModel` which retains the original semantic
2. both apis support `app` param to allow filtering data of specified app
