### PR TITLE
global-sidecar: fix non ns svc

### DIFF
--- a/staging/src/slime.io/slime/modules/lazyload/charts/global-sidecar/templates/cluster-global-sidecar.yaml
+++ b/staging/src/slime.io/slime/modules/lazyload/charts/global-sidecar/templates/cluster-global-sidecar.yaml
@@ -69,14 +69,14 @@ metadata:
   name: global-sidecar
   namespace: {{ $clusterGsNamespace }}
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - get
-  - list
-  - watch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -86,6 +86,33 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
+  name: global-sidecar
+subjects:
+  - kind: ServiceAccount
+    name: global-sidecar
+    namespace: {{ $clusterGsNamespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: global-sidecar
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: global-sidecar
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
   name: global-sidecar
 subjects:
 - kind: ServiceAccount

--- a/staging/src/slime.io/slime/modules/lazyload/charts/global-sidecar/templates/namespace-global-sidecar.yaml
+++ b/staging/src/slime.io/slime/modules/lazyload/charts/global-sidecar/templates/namespace-global-sidecar.yaml
@@ -73,6 +73,7 @@ rules:
   - ""
   resources:
   - configmaps
+  - services
   verbs:
   - get
   - list

--- a/staging/src/slime.io/slime/modules/lazyload/cmd/proxy/controller.go
+++ b/staging/src/slime.io/slime/modules/lazyload/cmd/proxy/controller.go
@@ -29,7 +29,7 @@ func NewController(indexer cache.Indexer, queue workqueue.RateLimitingInterface,
 	}
 }
 
-func (c *controller) Run(stopCh chan struct{}) {
+func (c *controller) Run(stopCh <-chan struct{}) {
 	defer runtime.HandleCrash()
 
 	defer c.queue.ShutDown()

--- a/staging/src/slime.io/slime/modules/lazyload/cmd/proxy/svcController.go
+++ b/staging/src/slime.io/slime/modules/lazyload/cmd/proxy/svcController.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+)
+
+func startSvcCache(ctx context.Context) error {
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		return err
+	}
+	client, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return err
+	}
+
+	lw := &cache.ListWatch{
+		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+			return client.CoreV1().Services("").List(ctx, metav1.ListOptions{})
+		},
+		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			return client.CoreV1().Services("").Watch(ctx, metav1.ListOptions{})
+		},
+	}
+
+	_, controller := cache.NewInformer(lw, &corev1.Service{}, 60, cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj interface{}) { handleSvcUpdate(nil, obj) },
+		UpdateFunc: func(oldObj, newObj interface{}) { handleSvcUpdate(oldObj, newObj) },
+		DeleteFunc: func(obj interface{}) { handleSvcDelete(obj) },
+	})
+
+	go controller.Run(nil)
+
+	if !cache.WaitForCacheSync(ctx.Done(), controller.HasSynced) {
+		return fmt.Errorf("failed to wait for service cache sync")
+	}
+
+	return nil
+}
+
+func handleSvcUpdate(old, obj interface{}) {
+	svc, ok := obj.(*corev1.Service)
+	if !ok {
+		return
+	}
+	nn := types.NamespacedName{
+		Name:      svc.Name,
+		Namespace: svc.Namespace,
+	}
+
+	Cache.Set(nn)
+}
+
+func handleSvcDelete(obj interface{}) {
+	svc, ok := obj.(*corev1.Service)
+	if !ok {
+		return
+	}
+	nn := types.NamespacedName{
+		Name:      svc.Name,
+		Namespace: svc.Namespace,
+	}
+	Cache.Delete(nn)
+}

--- a/staging/src/slime.io/slime/modules/lazyload/pkg/proxy/cache.go
+++ b/staging/src/slime.io/slime/modules/lazyload/pkg/proxy/cache.go
@@ -1,0 +1,30 @@
+package proxy
+
+import (
+	"k8s.io/apimachinery/pkg/types"
+	"sync"
+)
+
+type Cache struct {
+	Data map[types.NamespacedName]struct{}
+	sync.RWMutex
+}
+
+func (c *Cache) Exist(nn types.NamespacedName) bool {
+	c.RLock()
+	defer c.RUnlock()
+	_, ok := c.Data[nn]
+	return ok
+}
+
+func (c *Cache) Set(nn types.NamespacedName) {
+	c.Lock()
+	defer c.Unlock()
+	c.Data[nn] = struct{}{}
+}
+
+func (c *Cache) Delete(nn types.NamespacedName) {
+	c.Lock()
+	defer c.Unlock()
+	delete(c.Data, nn)
+}


### PR DESCRIPTION
For short domains, such as `reviews`

globao-sidecar's previous logic was to extend it to reviews.{{ns}} and then forward it

This mr modifies this logic:

If reviews.{{ns}} exists in the cluster, then extend it.

If it doesn't exist, then forward it as the original request domain
