### PR TITLE
framework: util.AnyMessage impl JSONPBUnmarshaler

### DIFF
--- a/framework/model/module/module.go
+++ b/framework/model/module/module.go
@@ -392,23 +392,11 @@ func Main(bundle string, modules []Module) {
 				}
 			} else {
 				// new version: get mod.Config() value from config.general
-				if modCfg.General != nil {
-					rawMsg, ok := modSelfCfg.(*util.AnyMessage)
-					if len(modCfg.General.XXX_unrecognized) > 0 {
-						if ok {
-							rawMsg.Raw = modCfg.General.XXX_unrecognized
-						} else if err := proto.Unmarshal(modCfg.General.XXX_unrecognized, modSelfCfg); err != nil {
-							log.Errorf("unmarshal for mod %s XXX_unrecognized (%v) met err %v", modCfg.Name, modCfg.General.XXX_unrecognized, err)
-							fatal()
-						}
-					} else if len(modGeneralJson) > 0 {
-						u := jsonpb.Unmarshaler{AllowUnknownFields: true}
-						if ok {
-							rawMsg.RawJson = modGeneralJson
-						} else if err := u.Unmarshal(bytes.NewBuffer(modGeneralJson), modSelfCfg); err != nil {
-							log.Errorf("unmarshal for mod %s modGeneralJson (%v) met err %v", modCfg.Name, modGeneralJson, err)
-							fatal()
-						}
+				if len(modGeneralJson) > 0 {
+					u := jsonpb.Unmarshaler{AllowUnknownFields: true}
+					if err := u.Unmarshal(bytes.NewBuffer(modGeneralJson), modSelfCfg); err != nil {
+						log.Errorf("unmarshal for mod %s modGeneralJson (%v) met err %v", modCfg.Name, modGeneralJson, err)
+						fatal()
 					}
 				}
 			}

--- a/framework/util/util.go
+++ b/framework/util/util.go
@@ -4,6 +4,8 @@ import (
 	"flag"
 	"os"
 	"strings"
+
+	"github.com/gogo/protobuf/jsonpb"
 )
 
 const (
@@ -38,7 +40,6 @@ func Fatal() {
 }
 
 type AnyMessage struct {
-	Raw     []byte
 	RawJson []byte
 }
 
@@ -50,4 +51,9 @@ func (a *AnyMessage) String() string {
 }
 
 func (a *AnyMessage) ProtoMessage() {
+}
+
+func (a *AnyMessage) UnmarshalJSONPB(_ *jsonpb.Unmarshaler, data []byte) error {
+	a.RawJson = append([]byte{}, data...)
+	return nil
 }


### PR DESCRIPTION
Simplify the code
- AnyMessage only supports raw content in json format
- general config no longer supports unrecognized fields which means no longer supporting config in pb-bytes format