### PR TITLE
meshregistry: zk source add RefreshSidecarMockServiceEntry logic

### DIFF
--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/zookeeper/polling.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/zookeeper/polling.go
@@ -10,7 +10,6 @@ import (
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/libistio/pkg/config/event"
 	"istio.io/libistio/pkg/config/resource"
-	"istio.io/pkg/log"
 )
 
 func (s *Source) Polling() {
@@ -27,24 +26,6 @@ func (s *Source) Polling() {
 			}
 		}
 	}()
-}
-
-func (s *Source) markServiceEntryInitDone() {
-	s.mut.RLock()
-	ch := s.seInitCh
-	s.mut.RUnlock()
-	if ch == nil {
-		return
-	}
-
-	s.mut.Lock()
-	ch, s.seInitCh = s.seInitCh, nil
-	s.mut.Unlock()
-	if ch != nil {
-		log.Infof("service entry init done, close ch and call initWg.Done")
-		s.initWg.Done()
-		close(ch)
-	}
 }
 
 func (s *Source) refresh() {


### PR DESCRIPTION
We create a mock serviceentry that contains all known dubbo ports and update it continuously.

This serviceentry is used in conjunction with special pockets of Sidecar resources on the istio side to achieve the goal of allowing dubbo workloads that are temporarily dependent on the relationship location to also get all dubbo listeners.
