### PR TITLE
meshreg: fix panic of reclose ch in zk watching mode

### DIFF
--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/zookeeper/watching.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/zookeeper/watching.go
@@ -393,7 +393,7 @@ func (sw *ServiceWatcher) Start(ctx context.Context) {
 
 			paths, _, e, err := sw.conn.Load().(*zk.Conn).ChildrenW(sw.rootPath)
 			if err != nil {
-				if errors.Is(err, zk.ErrNoNode) {
+				if errors.Is(err, zk.ErrNoNode) && firstLoop {
 					// mark ready
 					firstLoop = false
 					close(initCh)


### PR DESCRIPTION
fix panic in corner case: root `/dubbo` node does not exist