### PR TITLE
meshregistry: sources support generating mock service which contains merged ports

### DIFF
--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/bootstrap/args.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/bootstrap/args.go
@@ -116,6 +116,9 @@ type SourceArgs struct {
 	EndpointSelectors []*metav1.LabelSelector `json:"EndpointSelectors,omitempty"`
 	// Endpoint selectors for specific service, the key of the map is the service name
 	ServicedEndpointSelectors map[string][]*metav1.LabelSelector `json:"ServicedEndpointSelectors,omitempty"`
+
+	MockServiceName      string `json:"MockServiceName,omitempty"`
+	MockServiceEntryName string `json:"MockServiceEntryName,omitempty"`
 }
 
 type K8SSourceArgs struct {

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/bootstrap/args.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/bootstrap/args.go
@@ -117,8 +117,10 @@ type SourceArgs struct {
 	// Endpoint selectors for specific service, the key of the map is the service name
 	ServicedEndpointSelectors map[string][]*metav1.LabelSelector `json:"ServicedEndpointSelectors,omitempty"`
 
-	MockServiceName      string `json:"MockServiceName,omitempty"`
-	MockServiceEntryName string `json:"MockServiceEntryName,omitempty"`
+	MockServiceName              string `json:"MockServiceName,omitempty"`
+	MockServiceEntryName         string `json:"MockServiceEntryName,omitempty"`
+	MockServiceMergeInstancePort bool   `json:"MockServiceMergeInstancePort,omitempty"`
+	MockServiceMergeServicePort  bool   `json:"MockServiceMergeServicePort,omitempty"`
 }
 
 type K8SSourceArgs struct {

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/server/processing.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/server/processing.go
@@ -150,7 +150,7 @@ func (p *Processing) Start() (err error) {
 	clusterCache := false
 
 	if srcArgs := p.regArgs.ZookeeperSource.SourceArgs; srcArgs.Enabled {
-		if zookeeperSrc, httpHandle, simpleHttpHandle, err = zookeeper.NewSource(p.regArgs.ZookeeperSource, kubeResources.All(), time.Duration(p.regArgs.RegistryStartDelay), p.httpServer.SourceReadyCallBack); err != nil {
+		if zookeeperSrc, httpHandle, simpleHttpHandle, err = zookeeper.New(p.regArgs.ZookeeperSource, kubeResources.All(), time.Duration(p.regArgs.RegistryStartDelay), p.httpServer.SourceReadyCallBack); err != nil {
 			return
 		}
 		p.httpServer.HandleFunc(zookeeper.ZkPath, httpHandle)

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/server/processing.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/server/processing.go
@@ -159,9 +159,9 @@ func (p *Processing) Start() (err error) {
 			p.httpServer.HandleFunc(zookeeper.DubboCallModelPath, zkSrc.HandleDubboCallModel)
 			p.httpServer.HandleFunc(zookeeper.SidecarDubboCallModelPath, zkSrc.HandleSidecarDubboCallModel)
 		}
-		p.httpServer.SourceRegistry(zookeeper.ZK)
+		p.httpServer.SourceRegistry(zookeeper.SourceName)
 		if srcArgs.WaitTime > 0 {
-			p.httpServer.SourceReadyLater(zookeeper.ZK, time.Duration(srcArgs.WaitTime))
+			p.httpServer.SourceReadyLater(zookeeper.SourceName, time.Duration(srcArgs.WaitTime))
 		}
 		clusterCache = clusterCache || p.regArgs.ZookeeperSource.LabelPatch
 	}

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/eureka/source.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/eureka/source.go
@@ -73,9 +73,12 @@ func New(args *bootstrap.EurekaSourceArgs, delay time.Duration, readyCallback fu
 		if args.MockServiceName == "" {
 			return nil, nil, fmt.Errorf("args MockServiceName empty but MockServiceEntryName %s", args.MockServiceEntryName)
 		}
-		svcMocker = source.NewServiceEntryMergePortMocker(args.MockServiceEntryName, args.ResourceNs, args.MockServiceName, map[string]string{
-			"registry": SourceName,
-		})
+		svcMocker = source.NewServiceEntryMergePortMocker(
+			args.MockServiceEntryName, args.ResourceNs, args.MockServiceName,
+			args.MockServiceMergeInstancePort, args.MockServiceMergeServicePort,
+			map[string]string{
+				"registry": SourceName,
+			})
 	}
 
 	ret := &Source{

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/nacos/polling.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/nacos/polling.go
@@ -35,10 +35,7 @@ func (s *Source) refresh() {
 	Scope.Infof("nacos refresh start : %d", time.Now().UnixNano())
 	s.updateServiceInfo()
 	Scope.Infof("nacos refresh finsh : %d", time.Now().UnixNano())
-	if !s.firstInited {
-		s.firstInited = true
-		s.initedCallback(SourceName)
-	}
+	s.markServiceEntryInitDone()
 }
 
 func (s *Source) updateServiceInfo() {
@@ -59,7 +56,7 @@ func (s *Source) updateServiceInfo() {
 			oldEntry.Endpoints = make([]*networking.WorkloadEntry, 0)
 			if event, err := buildEvent(event.Updated, oldEntry, service, s.resourceNs); err == nil {
 				Scope.Infof("delete(update) nacos se, hosts: %s ,ep: %s ,size : %d ", oldEntry.Hosts[0], printEps(oldEntry.Endpoints), len(oldEntry.Endpoints))
-				for _, h := range s.handler {
+				for _, h := range s.handlers {
 					h.Handle(event)
 				}
 			}
@@ -72,7 +69,7 @@ func (s *Source) updateServiceInfo() {
 			s.cache[service] = newEntry
 			if event, err := buildEvent(event.Added, newEntry, service, s.resourceNs); err == nil {
 				Scope.Infof("add nacos se, hosts: %s ,ep: %s, size: %d ", newEntry.Hosts[0], printEps(newEntry.Endpoints), len(newEntry.Endpoints))
-				for _, h := range s.handler {
+				for _, h := range s.handlers {
 					h.Handle(event)
 				}
 			}
@@ -82,7 +79,7 @@ func (s *Source) updateServiceInfo() {
 				s.cache[service] = newEntry
 				if event, err := buildEvent(event.Updated, newEntry, service, s.resourceNs); err == nil {
 					Scope.Infof("update nacos se, hosts: %s, ep: %s, size: %d ", newEntry.Hosts[0], printEps(newEntry.Endpoints), len(newEntry.Endpoints))
-					for _, h := range s.handler {
+					for _, h := range s.handlers {
 						h.Handle(event)
 					}
 				}

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/nacos/source.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/nacos/source.go
@@ -101,9 +101,12 @@ func New(args *bootstrap.NacosSourceArgs, nsHost bool, k8sDomainSuffix bool, del
 		if args.MockServiceName == "" {
 			return nil, nil, fmt.Errorf("args MockServiceName empty but MockServiceEntryName %s", args.MockServiceEntryName)
 		}
-		svcMocker = source.NewServiceEntryMergePortMocker(args.MockServiceEntryName, args.ResourceNs, args.MockServiceName, map[string]string{
-			"registry": "nacos",
-		})
+		svcMocker = source.NewServiceEntryMergePortMocker(
+			args.MockServiceEntryName, args.ResourceNs, args.MockServiceName,
+			args.MockServiceMergeInstancePort, args.MockServiceMergeServicePort,
+			map[string]string{
+				"registry": SourceName,
+			})
 	}
 
 	ret := &Source{

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/nacos/watching.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/nacos/watching.go
@@ -88,10 +88,7 @@ func (s *Source) watch() {
 	// Scope.Infof("nacos refresh start : %d", time.Now().UnixNano())
 	s.updateNacosService()
 	// Scope.Infof("nacos refresh finish : %d", time.Now().UnixNano())
-	if !s.firstInited {
-		s.firstInited = true
-		s.initedCallback(SourceName)
-	}
+	s.markServiceEntryInitDone()
 }
 
 func (s *Source) parseNacosService(serviceInfos model.ServiceList, subscribe bool) {
@@ -180,7 +177,7 @@ func (s *Source) deleteService(serviceName string) {
 			oldEntry.Endpoints = make([]*networking.WorkloadEntry, 0)
 			if event, err := buildEvent(event.Updated, oldEntry, service, s.resourceNs); err == nil {
 				Scope.Infof("delete(update) nacos se, hosts: %s ,ep: %s ,size : %d ", oldEntry.Hosts[0], printEps(oldEntry.Endpoints), len(oldEntry.Endpoints))
-				for _, h := range s.handler {
+				for _, h := range s.handlers {
 					h.Handle(event)
 				}
 			}
@@ -195,7 +192,7 @@ func (s *Source) updateService(newServiceEntryMap map[string]*networking.Service
 			s.cache[service] = newEntry
 			if event, err := buildEvent(event.Added, newEntry, service, s.resourceNs); err == nil {
 				Scope.Infof("add nacos se, hosts: %s ,ep: %s, size: %d ", newEntry.Hosts[0], printEps(newEntry.Endpoints), len(newEntry.Endpoints))
-				for _, h := range s.handler {
+				for _, h := range s.handlers {
 					h.Handle(event)
 				}
 			}
@@ -205,7 +202,7 @@ func (s *Source) updateService(newServiceEntryMap map[string]*networking.Service
 				s.cache[service] = newEntry
 				if event, err := buildEvent(event.Updated, newEntry, service, s.resourceNs); err == nil {
 					Scope.Infof("update nacos se, hosts: %s, ep: %s, size: %d ", newEntry.Hosts[0], printEps(newEntry.Endpoints), len(newEntry.Endpoints))
-					for _, h := range s.handler {
+					for _, h := range s.handlers {
 						h.Handle(event)
 					}
 				}

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/serviceentry.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/serviceentry.go
@@ -1,0 +1,107 @@
+package source
+
+import (
+	networking "istio.io/api/networking/v1alpha3"
+	"istio.io/libistio/pkg/config/event"
+	"istio.io/libistio/pkg/config/resource"
+	"istio.io/libistio/pkg/config/schema/collections"
+	"sort"
+	"sync"
+	"time"
+)
+
+type ServiceEntryMergePortMocker struct {
+	resourceName, resourceNs, host string
+	resourceLabels                 map[string]string
+
+	dispatcher func(meta resource.Metadata, item *networking.ServiceEntry)
+
+	notifyCh   chan struct{}
+	portsCache map[uint32]*networking.Port
+	mut        sync.RWMutex
+}
+
+func NewServiceEntryMergePortMocker(resourceName, resourceNs, serviceHost string, resourceLabels map[string]string) *ServiceEntryMergePortMocker {
+	return &ServiceEntryMergePortMocker{
+		resourceName:   resourceName,
+		resourceNs:     resourceNs,
+		host:           serviceHost,
+		resourceLabels: resourceLabels,
+
+		notifyCh:   make(chan struct{}, 1),
+		portsCache: map[uint32]*networking.Port{},
+	}
+}
+
+// SetDispatcher should be called before `Run`
+func (m *ServiceEntryMergePortMocker) SetDispatcher(dispatcher func(meta resource.Metadata, item *networking.ServiceEntry)) {
+	m.dispatcher = dispatcher
+}
+
+func (m *ServiceEntryMergePortMocker) Refresh() {
+	se := &networking.ServiceEntry{
+		Hosts:      []string{m.host},
+		Ports:      make([]*networking.Port, 0),
+		Resolution: networking.ServiceEntry_STATIC,
+	}
+
+	m.mut.RLock()
+	for _, p := range m.portsCache {
+		se.Ports = append(se.Ports, p)
+	}
+	m.mut.RUnlock()
+	sort.Slice(se.Ports, func(i, j int) bool {
+		return se.Ports[i].Number < se.Ports[j].Number
+	})
+
+	if m.dispatcher != nil {
+		now := time.Now()
+		lbls := map[string]string{}
+		for k, v := range m.resourceLabels {
+			lbls[k] = v
+		}
+		meta := resource.Metadata{
+			FullName:    resource.FullName{Namespace: resource.Namespace(m.resourceNs), Name: resource.LocalName(m.resourceName)},
+			CreateTime:  now,
+			Version:     resource.Version(now.String()),
+			Labels:      lbls,
+			Annotations: map[string]string{},
+		}
+		m.dispatcher(meta, se)
+	}
+}
+
+func (m *ServiceEntryMergePortMocker) Start(stop <-chan struct{}) {
+	for {
+		select {
+		case <-stop:
+			return
+		case <-m.notifyCh:
+			m.Refresh()
+		}
+	}
+}
+
+func (m *ServiceEntryMergePortMocker) Handle(e event.Event) {
+	if e.Source != collections.K8SNetworkingIstioIoV1Alpha3Serviceentries || e.Resource.Metadata.FullName.Name == resource.LocalName(m.resourceName) {
+		return
+	}
+
+	se := e.Resource.Message.(*networking.ServiceEntry)
+	var newPort bool
+	m.mut.Lock()
+	for _, p := range se.Ports {
+		if _, ok := m.portsCache[p.Number]; !ok {
+			m.portsCache[p.Number] = p
+			newPort = true
+		}
+	}
+	m.mut.Unlock()
+
+	if newPort {
+		select {
+		case m.notifyCh <- struct{}{}:
+		default:
+		}
+	}
+}

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/serviceentry.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/serviceentry.go
@@ -5,6 +5,7 @@ import (
 	"istio.io/libistio/pkg/config/event"
 	"istio.io/libistio/pkg/config/resource"
 	"istio.io/libistio/pkg/config/schema/collections"
+	"slime.io/slime/modules/meshregistry/pkg/util"
 	"sort"
 	"sync"
 	"time"
@@ -103,5 +104,18 @@ func (m *ServiceEntryMergePortMocker) Handle(e event.Event) {
 		case m.notifyCh <- struct{}{}:
 		default:
 		}
+	}
+}
+
+func BuildServiceEntryEvent(kind event.Kind, se *networking.ServiceEntry, meta resource.Metadata) event.Event {
+	FillRevision(meta)
+	util.FillSeLabels(se, meta)
+	return event.Event{
+		Kind:   kind,
+		Source: collections.K8SNetworkingIstioIoV1Alpha3Serviceentries,
+		Resource: &resource.Instance{
+			Metadata: meta,
+			Message:  se,
+		},
 	}
 }

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/zookeeper/model.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/zookeeper/model.go
@@ -9,7 +9,6 @@ import (
 
 const (
 	wildcardNamespace = "*"
-	DubboNamespace    = "dubbo"
 )
 
 type ServiceEntryWithMeta struct {

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/zookeeper/polling.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/zookeeper/polling.go
@@ -75,7 +75,7 @@ func (s *Source) handleServiceData(cacheInUse cmap.ConcurrentMap, provider, cons
 		newSeWithMeta := &ServiceEntryWithMeta{
 			ServiceEntry: se,
 			Meta: resource.Metadata{
-				FullName:   resource.FullName{Namespace: DubboNamespace, Name: resource.LocalName(serviceKey)},
+				FullName:   resource.FullName{Namespace: resource.Namespace(s.resourceNs), Name: resource.LocalName(serviceKey)},
 				CreateTime: now,
 				Version:    resource.Version(now.String()),
 				Labels: map[string]string{

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/zookeeper/source.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/zookeeper/source.go
@@ -30,7 +30,7 @@ import (
 var scope = log.RegisterScope("zk", "zk debugging", 0)
 
 const (
-	SourceName                = "zk"
+	SourceName                = "zookeeper"
 	ZkPath                    = "/zk"
 	ZkSimplePath              = "/zks"
 	DubboCallModelPath        = "/dubboCallModel"
@@ -84,7 +84,7 @@ type Source struct {
 	seMergePortMocker *source.ServiceEntryMergePortMocker
 }
 
-func NewSource(args *bootstrap.ZookeeperSourceArgs, exceptedResources []collection.Schema, delay time.Duration, readyCallback func(string)) (event.Source, func(http.ResponseWriter, *http.Request), func(http.ResponseWriter, *http.Request), error) {
+func New(args *bootstrap.ZookeeperSourceArgs, exceptedResources []collection.Schema, delay time.Duration, readyCallback func(string)) (event.Source, func(http.ResponseWriter, *http.Request), func(http.ResponseWriter, *http.Request), error) {
 	ignoreLabels := make(map[string]string, 0)
 	for _, v := range args.IgnoreLabel {
 		ignoreLabels[v] = v
@@ -95,10 +95,13 @@ func NewSource(args *bootstrap.ZookeeperSourceArgs, exceptedResources []collecti
 		if args.MockServiceName == "" {
 			return nil, nil, nil, fmt.Errorf("args MockServiceName empty but MockServiceEntryName %s", args.MockServiceEntryName)
 		}
-		svcMocker = source.NewServiceEntryMergePortMocker(args.MockServiceEntryName, args.ResourceNs, args.MockServiceName, map[string]string{
-			"path":     args.MockServiceName,
-			"registry": "zookeeper",
-		})
+		svcMocker = source.NewServiceEntryMergePortMocker(
+			args.MockServiceEntryName, args.ResourceNs, args.MockServiceName,
+			args.MockServiceMergeInstancePort, args.MockServiceMergeServicePort,
+			map[string]string{
+				"path":     args.MockServiceName,
+				"registry": SourceName,
+			})
 	}
 
 	ret := &Source{

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/zookeeper/watching.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/zookeeper/watching.go
@@ -22,7 +22,7 @@ func (s *Source) ServiceNodeDelete(path string) {
 		if ses, ok := seMap.(cmap.ConcurrentMap); ok {
 			for serviceKey, value := range ses.Items() {
 				if se, ok := value.(*ServiceEntryWithMeta); ok {
-					if event, err := buildSeEvent(event.Deleted, se.ServiceEntry, se.Meta, service, nil); err == nil {
+					if event, err := buildSeEvent(event.Deleted, se.ServiceEntry, se.Meta, nil); err == nil {
 						for _, h := range s.handlers {
 							h.Handle(event)
 						}


### PR DESCRIPTION

changes:

1. refactor the merge-ports-to-mock-serviceentry logic in zk source into a standalone component `ServiceEntryMergePortMocker`;

2. use the `...Mocker` to add the same feature to other sources: `nacos` and `eureka`;

3. align the init-source code of sources;
