### PR TITLE
lazyload:passthrough ipv4:port

### DIFF
--- a/boot/publish.sh
+++ b/boot/publish.sh
@@ -5,6 +5,7 @@ MODS=${MODS:-"lazyload limiter plugin"}
 for m in $MODS; do
   rm -rf "./helm-charts/slimeboot/templates/modules/$m"
   cp -r "../staging/src/slime.io/slime/modules/$m/charts/" "./helm-charts/slimeboot/templates/modules/$m"
+  rm -rf "./helm-charts/slimeboot/templates/modules/$m/crds"
 done
 find ./helm-charts/slimeboot/templates/modules -type f | grep -v ".yaml" | xargs --no-run-if-empty  rm -f 
 for e in Chart.yaml values.yaml; do

--- a/staging/src/slime.io/slime/modules/lazyload/charts/global-sidecar/templates/cluster-global-sidecar.yaml
+++ b/staging/src/slime.io/slime/modules/lazyload/charts/global-sidecar/templates/cluster-global-sidecar.yaml
@@ -329,6 +329,7 @@ spec:
                   route:
                     {{- if eq .cluster "_GLOBAL_SIDECAR" }}
                     cluster: outbound|{{$svcPort}}||global-sidecar.{{ $clusterGsNamespace }}.svc.cluster.local
+                    timeout: 0s
                     {{- else }}
                     cluster: {{ tpl .cluster $ }}
               # (dict "fence" $f "dispatch" . "root" $ "Template" (dict "BasePath" "xx"))
@@ -339,6 +340,17 @@ spec:
               - '*'
               name: to_global_sidecar
               routes:
+                - match:
+                    prefix: /
+                    headers:
+                    - name: ':authority'
+                      string_match:
+                        safe_regex:
+                          google_re2: {}
+                          regex: '^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(?::([1-9]|[1-9]\d{1,3}|[1-5]\d{4}|6[0-5][0-5][0-3][0-5]))?$'
+                  route:
+                    cluster: PassthroughCluster
+                    timeout: 0s
                 - match:
                     prefix: /
                   route:


### PR DESCRIPTION
懒加载需将首次请求转发只global-sidecar

但实际场景中，很多ipv4:port的请求也被转发到了global-sidecar，这样只会白白增加一跳

所以我们在兜底逻辑中增加一步，如果请求符合ipv4:port，将直接passthrough，不再兜底到global-sidecar
