### PR TITLE
fix: rm unused field which casued unable to deserialize slimeboot

### DIFF
--- a/staging/src/slime.io/slime/modules/lazyload/controllers/update_resources.go
+++ b/staging/src/slime.io/slime/modules/lazyload/controllers/update_resources.go
@@ -121,7 +121,6 @@ type Module struct {
 	Enable  bool                  `protobuf:"varint,7,opt,name=enable,proto3" json:"enable,omitempty"`
 	General *lazyloadconfig.Fence `protobuf:"bytes,8,opt,name=general,proto3" json:"general,omitempty"`
 	Bundle  *config.Bundle        `protobuf:"bytes,9,opt,name=bundle,proto3" json:"bundle,omitempty"`
-	Mode    config.Config_Mode    `protobuf:"varint,10,opt,name=mode,proto3,enum=slime.config.v1alpha1.Config_Mode" json:"mode,omitempty"`
 	// like bundle item kind, necessary if not bundle
 	Kind string `protobuf:"bytes,11,opt,name=kind,proto3" json:"kind,omitempty"`
 }


### PR DESCRIPTION
在bundle模式中，我们用mode字段指明子模块组织形式

```
    - name: limiter
      kind: limiter
      enable: true
      mode: BundleItem
```

在lazyload中我们需要读取slimeboot进行update操作，该流程中slimeboot使用的是自己构建的结构

导致无法反序列化，所以暂时在update过程中删除这一暂无使用的字段。

之后的解决方案是lazyalod update使用framework提供的slimeboot结构

todo: https://github.com/slime-io/slime/issues/323
