### PR TITLE
meshreg: support fetching instances from multiple nacos clusters

### DIFF
--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/nacos/source.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/nacos/source.go
@@ -111,30 +111,26 @@ func New(args *bootstrap.NacosSourceArgs, nsHost bool, k8sDomainSuffix bool, del
 	}
 
 	ret := &Source{
-		args: args,
-
-		namespace:       args.Namespace,
-		group:           args.Group,
-		delay:           delay,
-		refreshPeriod:   time.Duration(args.RefreshPeriod),
-		mode:            args.Mode,
-		svcNameWithNs:   args.NameWithNs,
-		started:         false,
-		gatewayModel:    args.GatewayModel,
-		patchLabel:      args.LabelPatch,
-		svcPort:         args.SvcPort,
-		nsHost:          nsHost,
-		k8sDomainSuffix: k8sDomainSuffix,
-		defaultSvcNs:    args.DefaultServiceNs,
-		resourceNs:      args.ResourceNs,
-
-		initedCallback: readyCallback,
-
+		args:              args,
+		namespace:         args.Namespace,
+		group:             args.Group,
+		delay:             delay,
+		refreshPeriod:     time.Duration(args.RefreshPeriod),
+		mode:              args.Mode,
+		svcNameWithNs:     args.NameWithNs,
+		started:           false,
+		gatewayModel:      args.GatewayModel,
+		patchLabel:        args.LabelPatch,
+		svcPort:           args.SvcPort,
+		nsHost:            nsHost,
+		k8sDomainSuffix:   k8sDomainSuffix,
+		defaultSvcNs:      args.DefaultServiceNs,
+		resourceNs:        args.ResourceNs,
+		initedCallback:    readyCallback,
 		cache:             make(map[string]*networking.ServiceEntry),
 		namingServiceList: cmap.New(),
 		stop:              make(chan struct{}),
 		seInitCh:          make(chan struct{}),
-
 		seMergePortMocker: svcMocker,
 	}
 
@@ -149,15 +145,11 @@ func New(args *bootstrap.NacosSourceArgs, nsHost bool, k8sDomainSuffix bool, del
 		}
 	}
 	if args.Mode == POLLING {
-		ret.client = NewClient(args.Address,
-			args.Username,
-			args.Password,
-			args.Namespace,
-			args.Group,
-			args.MetaKeyNamespace,
-			args.MetaKeyGroup,
-			args.AllNamespaces,
-			headers)
+		servers := args.Servers
+		if len(servers) == 0 {
+			servers = []bootstrap.NacosServer{args.NacosServer}
+		}
+		ret.client = NewClients(servers, args.MetaKeyNamespace, args.MetaKeyGroup, headers)
 	} else {
 		namingClient, err := newNamingClient(args.Address, args.Namespace, headers)
 		if err != nil {

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/nacos/watching.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/nacos/watching.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/nacos-group/nacos-sdk-go/v2/clients"
+	nacosClients "github.com/nacos-group/nacos-sdk-go/v2/clients"
 	"github.com/nacos-group/nacos-sdk-go/v2/clients/naming_client"
 	"github.com/nacos-group/nacos-sdk-go/v2/common/constant"
 	"github.com/nacos-group/nacos-sdk-go/v2/model"
@@ -52,7 +52,7 @@ func newNamingClient(addresses []string, namespace string, header map[string]str
 		})
 	}
 
-	namingClient, err := clients.NewNamingClient(
+	namingClient, err := nacosClients.NewNamingClient(
 		vo.NacosClientParam{
 			ClientConfig:  clientConfig,
 			ServerConfigs: serverConfigs,


### PR DESCRIPTION
For multiple nacos clusters, we aggregate instances based on service names


Usage:

``` yaml
LEGACY:
  NacosSource:
    Enabled: true
    Servers:
    # fetch instances from all namespace in server 1.1.1.1
    - Address:
      - "http://1.1.1.1:8848"
      AllNamespaces: true
    # fetch instances from namespace public and group DEFAULT_GROUP in server 2.2.2.2
    - Address:
      - "http://2.2.2.2:8848"
    # fetch instances from namespace ns1 and group group1 in server 3.3.3.3
    - Address:
      - "http://3.3.3.3:8848"
      Namespace: ns1
      Group: group1
    Mode: polling

# compatible with the original configuration
LEGACY:
  NacosSource:
    Enabled: true
    # fetch instances from all namespace in server 1.1.1.1
    Address:
    - "http://1.1.1.1:8848"
    AllNamespaces: true
    Mode: polling
```