### PR TITLE
global-sidecar: add env DISABLE_SVC_CONTROLLER

### DIFF
--- a/staging/src/slime.io/slime/modules/lazyload/pkg/proxy/http.go
+++ b/staging/src/slime.io/slime/modules/lazyload/pkg/proxy/http.go
@@ -66,7 +66,10 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 				Name:      svcName,
 			}
 
-			if p.SvcCache.Exist(nn) {
+			// it means svc controller is disabled when SvcCache is nil,
+			// so, all short domain should add ns info
+
+			if p.SvcCache == nil || p.SvcCache.Exist(nn) {
 				if idx >= 0 {
 					// add port info
 					reqHost = fmt.Sprintf("%s.%s:%s", nn.Name, nn.Namespace, port)


### PR DESCRIPTION
支持关闭 global sidecar中的svc controller

```
- name: DISABLE_SVC_CONTROLLER
  value: "true"
```

没有 DISABLE_SVC_CONTROLLER 变量或者 值为false都表示，开启svc controller
