### PR TITLE
meshreg: nacos source support custom instance service name

### DIFF
--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/bootstrap/args.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/bootstrap/args.go
@@ -121,6 +121,40 @@ type SourceArgs struct {
 	MockServiceEntryName         string `json:"MockServiceEntryName,omitempty"`
 	MockServiceMergeInstancePort bool   `json:"MockServiceMergeInstancePort,omitempty"`
 	MockServiceMergeServicePort  bool   `json:"MockServiceMergeServicePort,omitempty"`
+
+	// ServiceNaming is used to reassign the service to which the instance belongs
+	ServiceNaming *ServiceNameConverter `json:"ServiceNaming,omitempty"`
+}
+
+// ServiceNameConverter configures the service name of an instance,
+// using Seq to connect the substring configured by each item.
+type ServiceNameConverter struct {
+	Sep   string              `json:"Sep,omitempty"`
+	Items []ServiceNamingItem `json:"Items,omitempty"`
+}
+
+type ServiceNameItemKind string
+
+var (
+	InstanceBasicInfoKind ServiceNameItemKind = "$"
+	InstanceMetadataKind  ServiceNameItemKind = "meta"
+	StaticKind            ServiceNameItemKind = "static"
+
+	InstanceBasicInfoSvc  string = "service"
+	InstanceBasicInfoIP   string = "ip"
+	InstanceBasicInfoPort string = "port"
+)
+
+// ServiceNamingItem configure how a service name substring is generated.
+// The Kind field indicates the data source of the substring and
+// configurable values are `$`, `static` and `meta`.
+//   - `$`: basic information of the instance, supports `service`(the original service name of the instance),
+//     `ip`(the instance ip), `port`(the instance port).
+//   - `meta`: metadata of the instance, the value of the Value field is the extracted key specified in the metadata.
+//   - `static`: static configuration, directly using the value of the Value field.
+type ServiceNamingItem struct {
+	Kind  ServiceNameItemKind `json:"Kind,omitempty"`
+	Value string              `json:"Value,omitempty"`
 }
 
 type K8SSourceArgs struct {

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/nacos/polling.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/nacos/polling.go
@@ -44,6 +44,9 @@ func (s *Source) updateServiceInfo() {
 		log.Errorf("get nacos instances failed: " + err.Error())
 		return
 	}
+	if s.reGroupInstances != nil {
+		instances = s.reGroupInstances(instances)
+	}
 	newServiceEntryMap, err := ConvertServiceEntryMap(instances, s.defaultSvcNs, s.gatewayModel, s.svcPort, s.nsHost, s.k8sDomainSuffix, s.patchLabel, s.getInstanceFilters())
 	if err != nil {
 		log.Errorf("convert nacos servceentry map failed: " + err.Error())


### PR DESCRIPTION
At some point we need to regroup the instances that fetch from the registry, which means reassigning them to new `Service`. For this, we need a mechanism to customize the instance service name, then group the instances by the new service name.

We introduced the `ServiceNaming` field in the `SourceArgs` to configure to enable Rename&Regroup. A nonil `ServiceNaming` means enable.

The struct of `ServiceNaming` is 

``` go
type ServiceNameConverter struct {
    Sep   string              `json:"Sep,omitempty"`
    Items []ServiceNamingItem `json:"Items,omitempty"`
}

type ServiceNamingItem struct {
    Kind  ServiceNameItemKind `json:"Kind,omitempty"`
    Value string              `json:"Value,omitempty"`
}
```

Each `ServiceNamingItem` configure how a service name substring is generated, then using the `Seq` to connect the substrings. 

In ServiceNamingItem, The Kind field indicates the data source of the substring and configurable values are `$`, `static` and `meta`.

-  `$`: basic information of the instance, supports `service`(the original service name of the instance), `ip`(the instance ip), `port`(the instance port). 
- `meta`: metadata of the instance, the value of the Value field is the extracted key specified in the metadata.
- `static`: static configuration, directly using the value of the Value field. 

**NOTE: only support nacos source for now.**

---
For example:

An instance with a registered service name of `demo` and a metadata include of `env:prod` will have a new service name of `demo.prod`. When using the following configuration:

``` yaml
LEGACY:
  NacosSource:
    Enabled: true
    Address:
    - "http://1.1.1.1:8848"
    Mode: polling
    ServiceNaming:
      Sep: "."
      Items:
      - Kind: "$"
        Value: "service"
      - Kind: "meta"
        Value: "env"
```
