### PR TITLE
meshreg: nacos source support adding service host aliases

### DIFF
--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/bootstrap/args.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/bootstrap/args.go
@@ -124,6 +124,14 @@ type SourceArgs struct {
 
 	// ServiceNaming is used to reassign the service to which the instance belongs
 	ServiceNaming *ServiceNameConverter `json:"ServiceNaming,omitempty"`
+	// ServiceHostAliases allows configuring additional aliases for the specified service host
+	ServiceHostAliases []*ServiceHostAlias `json:"ServiceHostAliases,omitempty"`
+}
+
+// ServiceHostAlias includes the original host and all aliases of the original host
+type ServiceHostAlias struct {
+	Host    string   `json:"Host,omitempty"`
+	Aliases []string `json:"Aliases,omitempty"`
 }
 
 // ServiceNameConverter configures the service name of an instance,

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/nacos/polling.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/nacos/polling.go
@@ -47,7 +47,7 @@ func (s *Source) updateServiceInfo() {
 	if s.reGroupInstances != nil {
 		instances = s.reGroupInstances(instances)
 	}
-	newServiceEntryMap, err := ConvertServiceEntryMap(instances, s.defaultSvcNs, s.gatewayModel, s.svcPort, s.nsHost, s.k8sDomainSuffix, s.patchLabel, s.getInstanceFilters())
+	newServiceEntryMap, err := ConvertServiceEntryMap(instances, s.defaultSvcNs, s.gatewayModel, s.svcPort, s.nsHost, s.k8sDomainSuffix, s.patchLabel, s.getInstanceFilters(), s.getServiceHostAlias())
 	if err != nil {
 		log.Errorf("convert nacos servceentry map failed: " + err.Error())
 		return


### PR DESCRIPTION
Previously using the service name or [a custom service name](https://github.com/slime-io/slime/pull/330) as the only host for the generated `ServiceEntry`, additional hosts are now supported for the `ServiceEntry`.

Use `[]*ServiceHostAlias` to configure the original host and all aliases of the original host, if the original host is configured, the `Source` should append the aliases when convert a ServiceEntry .

**NOTE: only nacos source support for now**

---
usage:

the nacos service `foo.go` will be converted to a `ServiceEntry` with hosts `foo.go,bar.go`

``` yaml
LEGACY:
  NacosSource:
    Enabled: true
    Address:
    - "http://1.1.1.1:8848"
    Mode: polling
    ServiceHostAliases:
    - Host: foo.go
      Aliases:
      - "bar.go" 
```