### PR TITLE
meshreg: make the source scoped EndpointepSelector as the default service-scoped endpoint selector

### DIFF
--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/bootstrap/args.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/bootstrap/args.go
@@ -114,8 +114,11 @@ type SourceArgs struct {
 	// A list of selectors that specify the set of service instances to be processed,
 	// configured in the same way as the k8s label selector.
 	EndpointSelectors []*metav1.LabelSelector `json:"EndpointSelectors,omitempty"`
-	// Endpoint selectors for specific service, the key of the map is the service name
+	// Endpoint selectors for specific service, the key of the map is the service name.
+	// If a service matched a ServicedEndpointSelector the source scoped EndpointSelectors should be ignore.
 	ServicedEndpointSelectors map[string][]*metav1.LabelSelector `json:"ServicedEndpointSelectors,omitempty"`
+	// EmptyEpSelectorsExcludeAll if set to true, when no ep selectors are configured, the source should exclude all eps.
+	EmptyEpSelectorsExcludeAll bool `json:"EmptyEpSelectorsExcludeAll,omitempty"`
 
 	MockServiceName              string `json:"MockServiceName,omitempty"`
 	MockServiceEntryName         string `json:"MockServiceEntryName,omitempty"`

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/selector.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/selector.go
@@ -7,13 +7,15 @@ import (
 
 type SelectHookStore map[string]SelectHook
 
+// SelectHook returns TRUE if matched
 type SelectHook func(map[string]string) bool
 
 // NewSelectHook build a SelectHook by the input LabelSelectors.
-// If the input LabelSelectors is nil, the returned hook always returns TRUE.
-func NewSelectHook(labelSelectors []*metav1.LabelSelector) SelectHook {
+// If the input LabelSelectors is nil, the returned hook returns
+// the emptySelectorsReturn.
+func NewSelectHook(labelSelectors []*metav1.LabelSelector, emptySelectorsReturn bool) SelectHook {
 	if len(labelSelectors) == 0 {
-		return func(_ map[string]string) bool { return true }
+		return func(_ map[string]string) bool { return emptySelectorsReturn }
 	}
 	var selectors []labels.Selector
 	for _, selector := range labelSelectors {
@@ -38,10 +40,10 @@ func NewSelectHook(labelSelectors []*metav1.LabelSelector) SelectHook {
 }
 
 // NewSelectHookStore returns a SelectHookStore
-func NewSelectHookStore(groupedSelectors map[string][]*metav1.LabelSelector) SelectHookStore {
+func NewSelectHookStore(groupedSelectors map[string][]*metav1.LabelSelector, emptySelectorsReturn bool) SelectHookStore {
 	m := make(map[string]SelectHook, len(groupedSelectors))
 	for key, sels := range groupedSelectors {
-		m[key] = NewSelectHook(sels)
+		m[key] = NewSelectHook(sels, emptySelectorsReturn)
 	}
 	return m
 }


### PR DESCRIPTION
In https://github.com/slime-io/slime/pull/295, we introduced the source-scoped endpoint selector, and in https://github.com/slime-io/slime/pull/306, we introduced the service-scoped endpoint selector. We require instances to satisfy both scope endpoint selectors, which has limited our capabilities in practice.

In fact, if a service has a service-scoped endpoint selector, it can be configured to include the requirements of a source-scoped endpoint selector. In this case, the source-scoped endpoint selector will exist as the default service-scoped endpoint selector if not specified, giving us more flexibility in configuring the default behavior.