### PR TITLE
meshreg: support for adding additional metadata to a serviceentry

### DIFF
--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/bootstrap/args.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/bootstrap/args.go
@@ -129,6 +129,13 @@ type SourceArgs struct {
 	ServiceNaming *ServiceNameConverter `json:"ServiceNaming,omitempty"`
 	// ServiceHostAliases allows configuring additional aliases for the specified service host
 	ServiceHostAliases []*ServiceHostAlias `json:"ServiceHostAliases,omitempty"`
+	// ServiceAdditionalMetas allows configuring additional metadata for the specified service when converting to a ServiceEntry
+	ServiceAdditionalMetas map[string]*MetadataWrapper `json:"ServiceAdditionalMetas,omitempty"`
+}
+
+type MetadataWrapper struct {
+	Annotations map[string]string `json:"Annotations,omitempty"`
+	Labels      map[string]string `json:"Labels,omitempty"`
 }
 
 // ServiceHostAlias includes the original host and all aliases of the original host

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/nacos/watching.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/nacos/watching.go
@@ -175,7 +175,7 @@ func (s *Source) deleteService(serviceName string) {
 		if service == serviceName {
 			// DELETE, set ep size to zero
 			oldEntry.Endpoints = make([]*networking.WorkloadEntry, 0)
-			if event, err := buildEvent(event.Updated, oldEntry, service, s.resourceNs); err == nil {
+			if event, err := buildEvent(event.Updated, oldEntry, service, s.resourceNs, nil); err == nil {
 				log.Infof("delete(update) nacos se, hosts: %s ,ep: %s ,size : %d ", oldEntry.Hosts[0], printEps(oldEntry.Endpoints), len(oldEntry.Endpoints))
 				for _, h := range s.handlers {
 					h.Handle(event)
@@ -190,7 +190,7 @@ func (s *Source) updateService(newServiceEntryMap map[string]*networking.Service
 		if oldEntry, ok := s.cache[service]; !ok {
 			// ADD
 			s.cache[service] = newEntry
-			if event, err := buildEvent(event.Added, newEntry, service, s.resourceNs); err == nil {
+			if event, err := buildEvent(event.Added, newEntry, service, s.resourceNs, nil); err == nil {
 				log.Infof("add nacos se, hosts: %s ,ep: %s, size: %d ", newEntry.Hosts[0], printEps(newEntry.Endpoints), len(newEntry.Endpoints))
 				for _, h := range s.handlers {
 					h.Handle(event)
@@ -200,7 +200,7 @@ func (s *Source) updateService(newServiceEntryMap map[string]*networking.Service
 			if !reflect.DeepEqual(oldEntry, newEntry) {
 				// UPDATE
 				s.cache[service] = newEntry
-				if event, err := buildEvent(event.Updated, newEntry, service, s.resourceNs); err == nil {
+				if event, err := buildEvent(event.Updated, newEntry, service, s.resourceNs, nil); err == nil {
 					log.Infof("update nacos se, hosts: %s, ep: %s, size: %d ", newEntry.Hosts[0], printEps(newEntry.Endpoints), len(newEntry.Endpoints))
 					for _, h := range s.handlers {
 						h.Handle(event)


### PR DESCRIPTION
In meshreg, we convert the external registration service to ServiceEntry, and we provide an ENV interface [`SE_LABEL_SELECTOR_KEYS`](https://github.com/slime-io/slime/pull/338) for configuring the extraction of metadata from ep to SE metadata, which will take effect on all services and requires the cooperation of ep. 

this pr add  a config interface `ServiceAdditionalMetas`, which can add its own unique metadata to the specified service through configuration.

**NOTE: only nacos source support for now**

---
usage:

config meshregistry nacos source as below:
```
NacosSource:
  Enabled: true
  Address:
  - "http://127.0.0.1:8848"
  Mode: polling
  ServiceAdditionalMetas:
    foo.go:
      Labels:
        additional/app: foo
```
we get a SE as:

``` json
{
   "type":"networking.istio.io/v1alpha3/ServiceEntry",
   "name":"foo.go",
   "labels":{
      "istio.io/rev":"mesh-reg",
      "registry":"nacos",
      "additional/app": "foo"
   }
}
```




