### PR TITLE
meshreg: support relabeling metadata for nacos instance

### DIFF
--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/bootstrap/args.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/bootstrap/args.go
@@ -131,6 +131,9 @@ type SourceArgs struct {
 	ServiceHostAliases []*ServiceHostAlias `json:"ServiceHostAliases,omitempty"`
 	// ServiceAdditionalMetas allows configuring additional metadata for the specified service when converting to a ServiceEntry
 	ServiceAdditionalMetas map[string]*MetadataWrapper `json:"ServiceAdditionalMetas,omitempty"`
+	// InstanceMetaRelabel is used to adjust the metadata of the instance.
+	// Note that ServiceNaming may refer to instance metadata, the InstanceMetaRelabel needs to be processed before ServiceNaming
+	InstanceMetaRelabel *InstanceMetaRelabel `json:"InstanceMetaRelabel,omitempty"`
 }
 
 type MetadataWrapper struct {
@@ -173,6 +176,27 @@ var (
 type ServiceNamingItem struct {
 	Kind  ServiceNameItemKind `json:"Kind,omitempty"`
 	Value string              `json:"Value,omitempty"`
+}
+
+// InstanceMetaRelabel is used to configure how to adjust the metadata of the instance.
+type InstanceMetaRelabel struct {
+	// Items is the InstanceMetaRelabelItem configuration list, which is executed sequentially,
+	// which means that the subsequent items will be processed on the results of the previous items.
+	Items []*InstanceMetaRelabelItem `json:"Items,omitempty"`
+}
+
+// InstanceMetaRelabelItem represents an item used for relabeling instance metadata.
+type InstanceMetaRelabelItem struct {
+	// The key that currently exists in the instance metadata.
+	Key string `json:"Key,omitempty"`
+	// TargetKey is the new key to be added to the instance metadata based on the original key.
+	TargetKey string `json:"TargetKey,omitempty"`
+	// Whether to overwrite the value of the TargetKey if it already exists in the instance metadata.
+	Overwirte bool `json:"Overwirte,omitempty"`
+	// ValuesMapping is a map that associates values of the Key to values of the TargetKey.
+	// If the Key's value is found in the map, the corresponding value is used for the TargetKey.
+	// If not, the original value is used for the TargetKey.
+	ValuesMapping map[string]string `json:"ValuesMapping,omitempty"`
 }
 
 type K8SSourceArgs struct {


### PR DESCRIPTION
`SourceArgs` adds `InstanceMetaRelabel` field to configure how to relabel instance metadata. The source implementation needs to be able to map the original metadata `Key` in the instance to the `TargetKey`, using the value of the `Key` as the value of the `TargetKey` by default, and remapping the value of the `Key` to another value as the value of the `TargetKey` if necessary.  When the `TargetKey` already exists, it is possible to overwrite or skip this relabel according to the `Overwrite` parameter.

**Note:** pr provides an implementation for nacos source only.

---

examle:  

1. Use the value of `namingPrefix` in the service instance metadata to concatenate the original service name above as the service name of the converted SE;
2. If the metadata `namingPrefix` does not exist , use the value of the metadata `env` instead;
3. If the value of `env` is `prod`, expand it to `product`.

``` yaml
LEGACY:
  NacosSource:
    Enabled: true
    Mode: polling
    Servers:
    - Address:
      - "127.0.0.1:8848"
    InstanceMetaRelabel:
      Items:
      - Key: env
        TargetKey: namingPrefix
        ValuesMapping:
          prod: "product"
    ServiceNaming:
      Sep: "."
      Items:
      - Kind: "meta"
        Value: "namingPrefix"
      - Kind: "$"
        Value: "service"
```