### PR TITLE
lazyload: report accesslog to leader

### DIFF
--- a/boot/helm-charts/slimeboot/templates/deployment.yaml
+++ b/boot/helm-charts/slimeboot/templates/deployment.yaml
@@ -1,7 +1,6 @@
 {{ range .Values.module }}
   {{- if .enable }}
   {{- if not (eq (default "" .mode) "BundleItem") }}
-
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -185,7 +184,42 @@ spec:
       name: mcp-over-xds
   selector:
     app: {{.name}}
-  {{- end }}
-  {{- end }}
-  {{- end }}
-
+{{- if or (eq (default "" .name) "lazyload") (eq (default "" .kind) "lazyload") }}
+{{- if and .global .global.misc }}
+{{- if eq .global.misc.enableLeaderElection "on" }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .name }}-leader
+  namespace: {{ $.Values.namespace}}
+  labels:
+    app: {{.name}}
+spec:
+  type: {{ $.Values.service.type }}
+  ports:
+    - port: {{ $.Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+    - port: {{ $.Values.service.auxiliaryPort }}
+      targetPort: aux-port
+      protocol: TCP
+      name: aux-port
+    - port: {{ $.Values.service.logSourcePort }}
+      targetPort: log-source-port
+      protocol: TCP
+      name: log-source-port
+    - port: {{ $.Values.service.mcpOverXdsPort }}
+      targetPort: 16010
+      protocol: TCP
+      name: mcp-over-xds
+  selector:
+    app: {{.name}}
+    slime.io/leader: "true"
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/doc/zh/slime-boot.md
+++ b/doc/zh/slime-boot.md
@@ -439,7 +439,7 @@ spec:
 
 以limiter为例，安装带有两个副本的limiter模块。
 
-我们需要设置`enable-leader-election: "on"`以及`replicaCount: 2` 可开启多副本模式。
+我们需要设置`enableLeaderElection: "on"`以及`replicaCount: 2` 可开启多副本模式。
 
 ```yaml
 apiVersion: config.netease.com/v1alpha1
@@ -463,7 +463,7 @@ spec:
         disableInsertGlobalRateLimit: true
       global:
         misc:
-          enable-leader-election: "on"
+          enableLeaderElection: "on"
 ```
 
 

--- a/framework/bootstrap/config.go
+++ b/framework/bootstrap/config.go
@@ -37,12 +37,12 @@ var defaultModuleConfig = &bootconfig.Config{
 			},
 		},
 		Misc: map[string]string{
-			"metrics-addr":           ":8080",
-			"aux-addr":               ":8081",
-			"enable-leader-election": "off",
-			"globalSidecarMode":      "namespace",
-			"metricSourceType":       "prometheus", // can be prometheus or accesslog
-			"logSourcePort":          ":8082",
+			"metrics-addr":         ":8080",
+			"aux-addr":             ":8081",
+			"enableLeaderElection": "off",
+			"globalSidecarMode":    "namespace",
+			"metricSourceType":     "prometheus", // can be prometheus or accesslog
+			"logSourcePort":        ":8082",
 			// which label keys of serviceEntry select endpoints
 			// will take effect when serviceEntry does not have workloadSelector field
 			"seLabelSelectorKeys": "app",
@@ -203,7 +203,8 @@ func (f ReadyManagerFunc) AddReadyChecker(name string, checker func() error) {
 
 type Environment struct {
 	Config *bootconfig.Config
-	// clientSet, not support crd
+
+	// clientSet, not support crd, it can use in anytime anywhere
 	K8SClient *kubernetes.Clientset
 	// dynamic client, support any resource
 	DynamicClient    dynamic.Interface

--- a/framework/model/module/module.go
+++ b/framework/model/module/module.go
@@ -311,7 +311,7 @@ func Main(bundle string, modules []Module) {
 	}
 
 	// setup for leaderelection
-	if mainModConfig.Global.Misc["enable-leader-election"] == "on" {
+	if mainModConfig.Global.Misc["enableLeaderElection"] == "on" {
 		// create a resource lock in the same namespace as the workload instance
 		rl, err := leaderelection.NewKubeResourceLock(conf, os.Getenv("WATCH_NAMESPACE"), bundle)
 		if err != nil {
@@ -487,7 +487,6 @@ func Main(bundle string, modules []Module) {
 			log.Errorf("problem running, %+v", err)
 		}
 	}()
-
 	wg.Wait()
 }
 

--- a/staging/src/slime.io/slime/modules/lazyload/charts/global-sidecar/templates/cluster-global-sidecar.yaml
+++ b/staging/src/slime.io/slime/modules/lazyload/charts/global-sidecar/templates/cluster-global-sidecar.yaml
@@ -505,7 +505,11 @@ data:
                 "endpoint": {
                   "address": {
                     "socket_address": {
+                      {{- if (eq $g.misc.enableLeaderElection "on") }}
+                      "address": "{{ .name }}-leader.{{ $g.slimeNamespace }}",
+                      {{- else }}
                       "address": "{{ .name }}.{{ $g.slimeNamespace }}",
+                      {{- end }}
                       "port_value": {{ $.Values.service.logSourcePort }}
                     }
                   }

--- a/staging/src/slime.io/slime/modules/lazyload/model/const.go
+++ b/staging/src/slime.io/slime/modules/lazyload/model/const.go
@@ -1,0 +1,5 @@
+package model
+
+const (
+	SlimeLeader = "slime.io/leader"
+)


### PR DESCRIPTION
之前存在的问题是：懒加载开启多副本模式时，global-sidecar的accesslog会上报至svc:lazyload.mesh-operator

但service后挂在多个pods，其中只有一个是主，用于真正处理accesslog, 那么上报至非主pods的accesslog并不能被处理

本MR实现以下内容：

如果开启多副本，会额外创建一个svc, 其selector如下

```yaml
apiVersion: v1
kind: Service
metadata:
  labels:
    app: lazyload
  name: lazyload-leader
  namespace: mesh-operator
spec:
  ports:
  ...
  selector:
    app: lazyload
    slime.io/leader: "true"
  sessionAffinity: None
  type: ClusterIP
status:
  loadBalancer: {}
```

成为主的pods会给自己加上label，并在退出时移除该labels
```yaml
slime.io/leader: "true"
```

而global-sidecar中remote accesslog server的地址为` lazyload-leader.mesh-operator`

这样就可以保证每次上报的accesslog都只会被主pods接收。
