### PR TITLE
 meshregistry: apply extra service ports to endpoint ports and do code clean

### DIFF
--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/bootstrap/args.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/bootstrap/args.go
@@ -106,8 +106,9 @@ type SourceArgs struct {
 	GatewayModel  bool          `json:"GatewayModel,omitempty"`
 	// patch instances label
 	LabelPatch bool `json:"LabelPatch,omitempty"`
-	// svc port for services
-	SvcPort uint32 `json:"SvcPort,omitempty"`
+	// svc port for services, 0 will be ignored
+	SvcPort               uint32 `json:"SvcPort,omitempty"`               // XXX
+	InstancePortAsSvcPort bool   `json:"InstancePortAsSvcPort,omitempty"` // TODO
 	// if empty, those endpoints with ns attr will be aggregated into a no-ns service like "foo"
 	DefaultServiceNs string `json:"DefaultServiceNs,omitempty"`
 	ResourceNs       string `json:"ResourceNs,omitempty"`

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/eureka/conversion.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/eureka/conversion.go
@@ -3,6 +3,7 @@ package eureka
 import (
 	"math"
 	"net"
+	"slime.io/slime/modules/meshregistry/pkg/source"
 	"sort"
 	"strings"
 
@@ -43,6 +44,10 @@ func ConvertServiceEntryMap(apps []*application, defaultSvcNs string, gatewayMod
 				seMap[k] = v
 			}
 		}
+	}
+
+	for _, se := range seMap {
+		source.ApplyServicePortToEndpoints(se)
 	}
 	return seMap, nil
 }

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/eureka/source.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/eureka/source.go
@@ -24,20 +24,9 @@ import (
 var log = model.ModuleLog.WithField(frameworkmodel.LogFieldKeyPkg, "eureka")
 
 type Source struct {
-	// worker        *util.Worker
-	delay         time.Duration
-	refreshPeriod time.Duration
+	args *bootstrap.EurekaSourceArgs
 
-	svcPort uint32
-
-	defaultSvcNs string
-	resourceNs   string
-
-	gatewayModel    bool
-	patchLabel      bool
-	nsHost          bool
-	k8sDomainSuffix bool
-	nsfEureka       bool
+	delay time.Duration
 
 	initedCallback func(string)
 	handlers       []event.Handler
@@ -81,17 +70,9 @@ func New(args *bootstrap.EurekaSourceArgs, delay time.Duration, readyCallback fu
 	}
 
 	ret := &Source{
-		delay:           delay,
-		refreshPeriod:   time.Duration(args.RefreshPeriod),
-		started:         false,
-		gatewayModel:    args.GatewayModel,
-		patchLabel:      args.LabelPatch,
-		svcPort:         args.SvcPort,
-		nsHost:          args.NsHost,
-		k8sDomainSuffix: args.K8sDomainSuffix,
-		defaultSvcNs:    args.DefaultServiceNs,
-		resourceNs:      args.ResourceNs,
-		nsfEureka:       args.NsfEureka,
+		args:    args,
+		delay:   delay,
+		started: false,
 
 		initedCallback: readyCallback,
 
@@ -144,7 +125,7 @@ func (s *Source) refresh() {
 		log.Errorf("get eureka app failed: " + err.Error())
 		return
 	}
-	newServiceEntryMap, err := ConvertServiceEntryMap(apps, s.defaultSvcNs, s.gatewayModel, s.patchLabel, s.svcPort, s.nsHost, s.k8sDomainSuffix, s.nsfEureka)
+	newServiceEntryMap, err := ConvertServiceEntryMap(apps, s.args.DefaultServiceNs, s.args.GatewayModel, s.args.LabelPatch, s.args.SvcPort, s.args.NsHost, s.args.K8sDomainSuffix, s.args.NsfEureka)
 	if err != nil {
 		log.Errorf("convert eureka servceentry map failed: " + err.Error())
 		return
@@ -155,7 +136,7 @@ func (s *Source) refresh() {
 			// DELETE, set ep size to zero
 			delete(s.cache, service)
 			oldEntry.Endpoints = make([]*networking.WorkloadEntry, 0)
-			if event, err := buildEvent(event.Updated, oldEntry, service, s.resourceNs); err == nil {
+			if event, err := buildEvent(event.Updated, oldEntry, service, s.args.ResourceNs); err == nil {
 				log.Infof("delete(update) eureka se, hosts: %s ,ep: %s ,size : %d ", oldEntry.Hosts[0], printEps(oldEntry.Endpoints), len(oldEntry.Endpoints))
 				for _, h := range s.handlers {
 					h.Handle(event)
@@ -168,7 +149,7 @@ func (s *Source) refresh() {
 		if oldEntry, ok := s.cache[service]; !ok {
 			// ADD
 			s.cache[service] = newEntry
-			if event, err := buildEvent(event.Added, newEntry, service, s.resourceNs); err == nil {
+			if event, err := buildEvent(event.Added, newEntry, service, s.args.ResourceNs); err == nil {
 				log.Infof("add eureka se, hosts: %s ,ep: %s, size: %d ", newEntry.Hosts[0], printEps(newEntry.Endpoints), len(newEntry.Endpoints))
 				for _, h := range s.handlers {
 					h.Handle(event)
@@ -178,7 +159,7 @@ func (s *Source) refresh() {
 			if !reflect.DeepEqual(oldEntry, newEntry) {
 				// UPDATE
 				s.cache[service] = newEntry
-				if event, err := buildEvent(event.Updated, newEntry, service, s.resourceNs); err == nil {
+				if event, err := buildEvent(event.Updated, newEntry, service, s.args.ResourceNs); err == nil {
 					log.Infof("update eureka se, hosts: %s, ep: %s, size: %d ", newEntry.Hosts[0], printEps(newEntry.Endpoints), len(newEntry.Endpoints))
 					for _, h := range s.handlers {
 						h.Handle(event)
@@ -247,7 +228,7 @@ func (s *Source) Start() {
 
 	go func() {
 		time.Sleep(s.delay)
-		ticker := time.NewTicker(s.refreshPeriod)
+		ticker := time.NewTicker(time.Duration(s.args.RefreshPeriod))
 		defer ticker.Stop()
 		for {
 			select {

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/nacos/conversion.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/nacos/conversion.go
@@ -3,6 +3,7 @@ package nacos
 import (
 	"math"
 	"net"
+	"slime.io/slime/modules/meshregistry/pkg/source"
 	"sort"
 	"strings"
 
@@ -32,6 +33,10 @@ func ConvertServiceEntryMap(instances []*instanceResp, defaultSvcNs string, gate
 				seMap[k] = v
 			}
 		}
+	}
+
+	for _, se := range seMap {
+		source.ApplyServicePortToEndpoints(se)
 	}
 	return seMap, nil
 }

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/nacos/source.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/nacos/source.go
@@ -36,25 +36,7 @@ type Source struct {
 	seMergePortMocker *source.ServiceEntryMergePortMocker
 
 	// common configs
-	group           string
-	patchLabel      bool
-	gatewayModel    bool
-	nsHost          bool
-	k8sDomainSuffix bool
-	allNamespaces   bool
-	namespace       string
-	namespaces      []string
-	svcPort         uint32
-	mode            string
-	delay           time.Duration
-	refreshPeriod   time.Duration
-
-	// waching configs
-	svcNameWithNs bool
-
-	// polling configs
-	defaultSvcNs string
-	resourceNs   string
+	delay time.Duration
 
 	// source cache
 	cache             map[string]*networking.ServiceEntry
@@ -120,20 +102,8 @@ func New(args *bootstrap.NacosSourceArgs, nsHost bool, k8sDomainSuffix bool, del
 
 	ret := &Source{
 		args:              args,
-		namespace:         args.Namespace,
-		group:             args.Group,
 		delay:             delay,
-		refreshPeriod:     time.Duration(args.RefreshPeriod),
-		mode:              args.Mode,
-		svcNameWithNs:     args.NameWithNs,
 		started:           false,
-		gatewayModel:      args.GatewayModel,
-		patchLabel:        args.LabelPatch,
-		svcPort:           args.SvcPort,
-		nsHost:            nsHost,
-		k8sDomainSuffix:   k8sDomainSuffix,
-		defaultSvcNs:      args.DefaultServiceNs,
-		resourceNs:        args.ResourceNs,
 		initedCallback:    readyCallback,
 		cache:             make(map[string]*networking.ServiceEntry),
 		namingServiceList: cmap.New(),
@@ -362,7 +332,7 @@ func (s *Source) Start() {
 	}
 
 	go func() {
-		if s.mode == POLLING {
+		if s.args.Mode == POLLING {
 			go s.Polling()
 		} else {
 			go s.Watching()

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/zookeeper/conversion.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/zookeeper/conversion.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/url"
 	"regexp"
+	"slime.io/slime/modules/meshregistry/pkg/source"
 	"sort"
 	"strconv"
 	"strings"
@@ -258,6 +259,10 @@ func convertServiceEntry(providers, consumers []string, service string, patchLab
 			se.Ports = append(se.Ports, port)
 			uniquePort[serviceKey][port.Number] = struct{}{}
 		}
+	}
+
+	for _, cse := range serviceEntryByServiceKey {
+		source.ApplyServicePortToEndpoints(cse.se)
 	}
 
 	return serviceEntryByServiceKey

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/zookeeper/sidecar.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/zookeeper/sidecar.go
@@ -153,7 +153,7 @@ func (s *Source) refreshSidecar(init bool) {
 	s.recordAppSidecarUpdateTime(diff)
 	s.mut.Unlock()
 
-	diffSidecars, deletedSidecars := convertDubboCallModelConfigToSidecar(s.resourceNs, mergedCallModels, diff, s.args.DubboWorkloadAppLabel)
+	diffSidecars, deletedSidecars := convertDubboCallModelConfigToSidecar(s.args.ResourceNs, mergedCallModels, diff, s.args.DubboWorkloadAppLabel)
 
 	sidecarMap := make(map[resource.FullName]SidecarWithMeta, len(diffSidecars))
 	for _, sc := range diffSidecars {

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/zookeeper/watching.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/zookeeper/watching.go
@@ -43,11 +43,11 @@ func (s *Source) Watching() {
 	log.Info("zk source start to watching")
 	sw := ServiceWatcher{
 		conn:               s.Con,
-		rootPath:           s.RegisterRootNode,
+		rootPath:           s.args.RegistryRootNode,
 		endpointUpdateFunc: s.EndpointUpdate,
 		serviceDeleteFunc:  s.ServiceNodeDelete,
-		gatewatModel:       s.zkGatewayModel,
-		workers:            make([]*worker, s.watchingWorkerCount),
+		gatewatModel:       s.args.GatewayModel,
+		workers:            make([]*worker, s.args.WatchingWorkerCount),
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
background:

1. for those services with out a explicit concept of `service port`,  we need to aggregate the whole ports of instances to service ports. For example: we have two ep 1.1.1.1:8080 and 2.2.2.2:8081. After aggregating the svc ports we get http-8080: 8080 and http-8081: 8081, each instance has one of the corresponding ports.

2. The istio side will extract the instance of the specified service port by: If no target port is specified and there is no instance port with the same name, the service port number is used directly as the instance port. This means that service port 8080 will get two instances 1.1.1.1:8080 and 2.2.2.2:8080. This is obviously not what we expected (the instance 2.2.2.2 is not listening on port 8080)

3. It leads to invalid instances in the corresponding cluster that is finally sent, and envoy cannot forward the traffic properly


After this function takes effect, we get: 1.1.1.1 http-8080: 8080 http-8081: 8080 and 2.2.2.2 http-8080: 8081 http-8081: 8081

```json
        "ports": [
          {
            "number": 20381,
            "protocol": "dubbo",
            "name": "dubbo-20381"
          },
          {
            "number": 20281,
            "protocol": "dubbo",
            "name": "dubbo-20281"
          }
        ],
        "resolution": "STATIC",
        "endpoints": [
          {
            "address": "1.1.1.1",
            "ports": {
              "dubbo-20281": 20381,
              "dubbo-20381": 20381
            },
          {
            "address": "2.2.2.2",
            "ports": {
              "dubbo-20281": 20281,
              "dubbo-20381": 20281
            },
```