### PR TITLE
meshregistry: align support of svcPort and instancePortAsSvcPort parameters for sources

### DIFF
--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/bootstrap/args.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/bootstrap/args.go
@@ -356,7 +356,7 @@ type K8SArgs struct {
 
 func NewRegistryArgs() *RegistryArgs {
 	a := *DefaultArgs()
-	return &RegistryArgs{
+	ret := &RegistryArgs{
 		Args:    a,
 		RevCrds: "sidecars,destinationrules,envoyfilters,gateways,virtualservices",
 		Mcp: &McpArgs{
@@ -378,9 +378,10 @@ func NewRegistryArgs() *RegistryArgs {
 		},
 		ZookeeperSource: &ZookeeperSourceArgs{
 			SourceArgs: SourceArgs{
-				RefreshPeriod: util.Duration(10 * time.Second),
-				LabelPatch:    true,
-				ResourceNs:    "dubbo",
+				RefreshPeriod:         util.Duration(10 * time.Second),
+				LabelPatch:            true,
+				ResourceNs:            "dubbo",
+				InstancePortAsSvcPort: true,
 			},
 			IgnoreLabel:                 []string{"pid", "timestamp", "dubbo"},
 			Mode:                        "polling",
@@ -394,9 +395,10 @@ func NewRegistryArgs() *RegistryArgs {
 		},
 		EurekaSource: &EurekaSourceArgs{
 			SourceArgs: SourceArgs{
-				RefreshPeriod: util.Duration(30 * time.Second),
-				LabelPatch:    true,
-				SvcPort:       80,
+				RefreshPeriod:         util.Duration(30 * time.Second),
+				LabelPatch:            true,
+				SvcPort:               80,
+				InstancePortAsSvcPort: true,
 				// should set it to "xx" explicitly to get the same behaviour as before("foo.eureka")
 				DefaultServiceNs: "",
 				ResourceNs:       "eureka",
@@ -406,15 +408,18 @@ func NewRegistryArgs() *RegistryArgs {
 		},
 		NacosSource: &NacosSourceArgs{
 			SourceArgs: SourceArgs{
-				RefreshPeriod:    util.Duration(30 * time.Second),
-				LabelPatch:       true,
-				SvcPort:          80,
-				DefaultServiceNs: "",
-				ResourceNs:       "nacos",
+				RefreshPeriod:         util.Duration(30 * time.Second),
+				LabelPatch:            true,
+				SvcPort:               80,
+				InstancePortAsSvcPort: true,
+				DefaultServiceNs:      "",
+				ResourceNs:            "nacos",
 			},
 			Mode:            "watching",
 			K8sDomainSuffix: true,
 			NsHost:          true,
 		},
 	}
+
+	return ret
 }

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/eureka/source.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/eureka/source.go
@@ -69,6 +69,10 @@ func New(args *bootstrap.EurekaSourceArgs, delay time.Duration, readyCallback fu
 			})
 	}
 
+	if !args.InstancePortAsSvcPort && args.SvcPort == 0 {
+		return nil, nil, fmt.Errorf("SvcPort == 0 while InstancePortAsSvcPort false is not permitted")
+	}
+
 	ret := &Source{
 		args:    args,
 		delay:   delay,
@@ -125,7 +129,9 @@ func (s *Source) refresh() {
 		log.Errorf("get eureka app failed: " + err.Error())
 		return
 	}
-	newServiceEntryMap, err := ConvertServiceEntryMap(apps, s.args.DefaultServiceNs, s.args.GatewayModel, s.args.LabelPatch, s.args.SvcPort, s.args.NsHost, s.args.K8sDomainSuffix, s.args.NsfEureka)
+	newServiceEntryMap, err := ConvertServiceEntryMap(
+		apps, s.args.DefaultServiceNs, s.args.GatewayModel, s.args.LabelPatch, s.args.SvcPort,
+		s.args.InstancePortAsSvcPort, s.args.NsHost, s.args.K8sDomainSuffix, s.args.NsfEureka)
 	if err != nil {
 		log.Errorf("convert eureka servceentry map failed: " + err.Error())
 		return

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/nacos/polling.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/nacos/polling.go
@@ -47,7 +47,9 @@ func (s *Source) updateServiceInfo() {
 	if s.reGroupInstances != nil {
 		instances = s.reGroupInstances(instances)
 	}
-	newServiceEntryMap, err := ConvertServiceEntryMap(instances, s.args.DefaultServiceNs, s.args.GatewayModel, s.args.SvcPort, s.args.NsHost, s.args.K8sDomainSuffix, s.args.LabelPatch, s.getInstanceFilters(), s.getServiceHostAlias())
+	newServiceEntryMap, err := ConvertServiceEntryMap(
+		instances, s.args.DefaultServiceNs, s.args.GatewayModel, s.args.SvcPort, s.args.NsHost, s.args.K8sDomainSuffix,
+		s.args.InstancePortAsSvcPort, s.args.LabelPatch, s.getInstanceFilters(), s.getServiceHostAlias())
 	if err != nil {
 		log.Errorf("convert nacos servceentry map failed: " + err.Error())
 		return

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/serviceentry.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/serviceentry.go
@@ -8,8 +8,13 @@ import (
 	"istio.io/libistio/pkg/config/schema/collections"
 	"slime.io/slime/modules/meshregistry/pkg/util"
 	"sort"
+	"strings"
 	"sync"
 	"time"
+)
+
+var (
+	ProtocolHTTP = "HTTP"
 )
 
 type ServiceEntryMergePortMocker struct {
@@ -183,4 +188,8 @@ func ApplyServicePortToEndpoints(se *networking.ServiceEntry) {
 			}
 		}
 	}
+}
+
+func PortName(protocol string, num uint32) string {
+	return fmt.Sprintf("%s-%d", strings.ToLower(protocol), num)
 }

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/zookeeper/conversion.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/zookeeper/conversion.go
@@ -180,7 +180,7 @@ func convertServiceEntry(
 		if instancePortAsSvcPort {
 			svcPortInUse = portNum
 		}
-		instPort := convertPort(svcPortInUse, portNum, !gatewayMode)
+		instPort := convertPort(svcPortInUse, portNum)
 
 		methods := map[string]struct{}{}
 		meta, ok := verifyMeta(providerParts[len(providerParts)-1], addr, patchLabel, ignoreLabels, func(method string) {
@@ -236,7 +236,7 @@ func convertServiceEntry(
 						log.Debugf("invalid consumer %s of %s", consumer, serviceKey)
 						cAddr = cAddr[:idx]
 					} else {
-						cPort = convertPort(portNum, portNum, !gatewayMode)
+						cPort = convertPort(portNum, portNum)
 						cAddr = addr
 					}
 				}
@@ -264,7 +264,7 @@ func convertServiceEntry(
 		}
 		for _, p := range svcPortsToAdd {
 			if _, ok := uniquePort[serviceKey][p]; !ok {
-				se.Ports = append(se.Ports, convertPort(p, p, !gatewayMode))
+				se.Ports = append(se.Ports, convertPort(p, p))
 				uniquePort[serviceKey][p] = struct{}{}
 			}
 		}
@@ -404,15 +404,11 @@ func parseDubboTag(str string, meta map[string]string) {
 	}
 }
 
-func convertPort(svcPort, port uint32, nameWithPort bool) *networking.Port {
-	name := DubboPortName
-	if nameWithPort {
-		name = source.PortName(NetworkProtocolDubbo, svcPort)
-	}
+func convertPort(svcPort, port uint32) *networking.Port {
 	return &networking.Port{
 		Protocol: NetworkProtocolDubbo,
 		Number:   port,
-		Name:     name,
+		Name:     source.PortName(NetworkProtocolDubbo, svcPort),
 	}
 }
 

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/zookeeper/polling.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/zookeeper/polling.go
@@ -1,15 +1,12 @@
 package zookeeper
 
 import (
-	"reflect"
-	"strconv"
 	"time"
 
 	"github.com/go-zookeeper/zk"
 	cmap "github.com/orcaman/concurrent-map"
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/libistio/pkg/config/event"
-	"istio.io/libistio/pkg/config/resource"
 )
 
 func (s *Source) Polling() {
@@ -61,106 +58,6 @@ func (s *Source) iface(service string) {
 	}
 
 	s.handleServiceData(s.pollingCache, providerChild, consumerChild, service)
-}
-
-func (s *Source) handleServiceData(cacheInUse cmap.ConcurrentMap, provider, consumer []string, service string) {
-	if _, ok := cacheInUse.Get(service); !ok {
-		cacheInUse.Set(service, cmap.New())
-	}
-
-	freshSeMap := convertServiceEntry(provider, consumer, service, s.args.LabelPatch, s.ignoreLabelsMap, s.args.GatewayModel)
-	for serviceKey, convertedSe := range freshSeMap {
-		se := convertedSe.se
-		now := time.Now()
-		newSeWithMeta := &ServiceEntryWithMeta{
-			ServiceEntry: se,
-			Meta: resource.Metadata{
-				FullName:   resource.FullName{Namespace: resource.Namespace(s.args.ResourceNs), Name: resource.LocalName(serviceKey)},
-				CreateTime: now,
-				Version:    resource.Version(now.String()),
-				Labels: map[string]string{
-					"path":            service,
-					"registry":        "zookeeper",
-					dubboParamMethods: convertedSe.methodsLabel,
-				},
-				Annotations: map[string]string{},
-			},
-		}
-
-		if !convertedSe.methodsEqual {
-			newSeWithMeta.Meta.Labels[DubboSvcMethodEqLabel] = strconv.FormatBool(convertedSe.methodsEqual)
-		}
-
-		v, ok := cacheInUse.Get(service)
-		if !ok {
-			continue
-		}
-		seCache, ok := v.(cmap.ConcurrentMap)
-		if !ok {
-			continue
-		}
-
-		callModel := convertDubboCallModel(se, convertedSe.InboundEndPoints)
-
-		if value, exist := seCache.Get(serviceKey); !exist {
-			seCache.Set(serviceKey, newSeWithMeta)
-			if ev, err := buildSeEvent(event.Added, newSeWithMeta.ServiceEntry, newSeWithMeta.Meta, callModel); err == nil {
-				log.Infof("add zk se, hosts: %s, ep size: %d ", newSeWithMeta.ServiceEntry.Hosts[0], len(newSeWithMeta.ServiceEntry.Endpoints))
-				for _, h := range s.handlers {
-					h.Handle(ev)
-				}
-			}
-		} else if existSeWithMeta, ok := value.(*ServiceEntryWithMeta); ok {
-			if reflect.DeepEqual(existSeWithMeta, newSeWithMeta) {
-				continue
-			}
-			seCache.Set(serviceKey, newSeWithMeta)
-			if ev, err := buildSeEvent(event.Updated, newSeWithMeta.ServiceEntry, newSeWithMeta.Meta, callModel); err == nil {
-				log.Infof("update zk se, hosts: %s, ep size: %d ", newSeWithMeta.ServiceEntry.Hosts[0], len(newSeWithMeta.ServiceEntry.Endpoints))
-				for _, h := range s.handlers {
-					h.Handle(ev)
-				}
-			}
-		}
-	}
-
-	// check if svc deleted
-	deleteKey := make([]string, 0)
-	v, ok := cacheInUse.Get(service)
-	if !ok {
-		return
-	}
-	seCache, ok := v.(cmap.ConcurrentMap)
-	if !ok {
-		return
-	}
-	for serviceKey, v := range seCache.Items() {
-		_, exist := freshSeMap[serviceKey]
-		if exist {
-			continue
-		}
-		deleteKey = append(deleteKey, serviceKey)
-		seValue, ok := v.(*ServiceEntryWithMeta)
-		if !ok {
-			continue
-		}
-
-		// del event -> empty-ep update event
-		seValue.ServiceEntry.Endpoints = make([]*networking.WorkloadEntry, 0)
-		ev, err := buildSeEvent(event.Updated, seValue.ServiceEntry, seValue.Meta, nil)
-		if err != nil {
-			log.Errorf("delete svc failed, case: %v", err.Error())
-			continue
-		}
-		log.Infof("delete(update) zk se, hosts: %s, ep size: %d ", seValue.ServiceEntry.Hosts[0], len(seValue.ServiceEntry.Endpoints))
-		for _, h := range s.handlers {
-			h.Handle(ev)
-		}
-	}
-
-	for _, key := range deleteKey {
-		seCache.Remove(key)
-	}
 }
 
 func (s *Source) handleNodeDelete(childrens []string) {


### PR DESCRIPTION
1. 通过统一的参数svcPort和instancePortAsSvcPort来控制相关的业务行为，减少各个source内的各自定制实现，提高可维护性

  * `svcPort`: 表示显式的svc port， 0值会被忽略；
 
  * `instancePortAsSvcPort` 为true时会将实例端口聚合为服务端口；

  实际`if svcPort != 0 && instancePortAsSvcPort` 时，会得到二者的并集作为最终的服务端口（列表）

2. 让eureka/nacos支持像dubbo 那样聚合实例端口为服务端口。 完善服务模型
