### PR TITLE
lazylaod:  support request_headers_to_add replace lua plugin to add headers

### DIFF
--- a/staging/src/slime.io/slime/modules/lazyload/charts/global-sidecar/templates/cluster-global-sidecar.yaml
+++ b/staging/src/slime.io/slime/modules/lazyload/charts/global-sidecar/templates/cluster-global-sidecar.yaml
@@ -12,6 +12,7 @@
           {{ $name := .name }}
           {{ $gsSvcPorts := list }}
           {{ $hasGsPort := false }}
+          {{ $addEnvHeaderViaLua := .global.misc.addEnvHeaderViaLua }}
           {{ $autoPort := .general.autoPort }}
           {{ $clusterGsNamespace := .general.clusterGsNamespace | default $.Values.namespace }}
           {{- range $f.wormholePort }}
@@ -362,6 +363,12 @@ spec:
                 key: "Slime-Orig-Dest"
                 value: "%DOWNSTREAM_LOCAL_ADDRESS%"
               append: true
+          {{- if ne $addEnvHeaderViaLua "true" }}
+            - header:
+                key: "Slime-Source-Ns"
+                value: "%ENVIRONMENT(POD_NAMESPACE)%"
+          {{- end }}
+{{- if eq $addEnvHeaderViaLua "true" }}
     - applyTo: HTTP_FILTER
       match:
         context: SIDECAR_OUTBOUND
@@ -407,6 +414,7 @@ spec:
             envoy.filters.http.lua:
               "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.LuaPerRoute
               name: add.lua
+{{- end }}
     - applyTo: VIRTUAL_HOST
       match:
         proxy:


### PR DESCRIPTION
背景：懒加载将首次访问兜底到global-sidecar时，用lua插件方式给请求加上了 Slime-Source-Ns （即请求发起方所在ns）

但在大规模场景下，lua性能有所欠缺。

------

本次改动：envoy 在1.22以及之后(对应的istio应该是 1.14.1 / 1.13.5 / 1.12.8)，支持了从env获取变量，并添加到路由的功能

```yaml
          request_headers_to_add:
            - header:
                key: "Slime-Source-Ns"
                value: "%ENVIRONMENT(POD_NAMESPACE)%"
```

所以我们修改了默认行为 


只有设置了addEnvHeaderViaLua，才会采用lua方式获取头，

否者我们用 request_headers_to_add 方式添加 Slime-Source-Ns（如果不设置我们将会才用request_headers_to_add ）

**需要关注的是，只有在1.14.1后的版本才支持request_headers_to_add，对于不支持的版本用户需要设置addEnvHeaderViaLua**


------

采用request_headers_to_add方式，envoyfilter(to-global-sidecar)效果如下

```yaml
  - applyTo: ROUTE_CONFIGURATION
    match:
      context: SIDECAR_OUTBOUND
      routeConfiguration:
        name: "9088"
    patch:
      operation: MERGE
      value:
        request_headers_to_add:
        - append: true
          header:
            key: Slime-Orig-Dest
            value: '%DOWNSTREAM_LOCAL_ADDRESS%'
        - header:
            key: Slime-Source-Ns
            value: '%ENVIRONMENT(POD_NAMESPACE)%'
```

------

addEnvHeaderViaLua 设置方式如下（采用lua方式）

**对于不支持的版本用户需要设置addEnvHeaderViaLua** 设置方式如下

```yaml
apiVersion: config.netease.com/v1alpha1
kind: SlimeBoot
metadata:
  name: lazyload
  namespace: mesh-operator
spec:
  image:
    pullPolicy: Always
    repository: docker.io/slimeio/slime-lazyload
    tag: xxxxxxx 
  namespace: mesh-operator
  istioNamespace: istio-system
  module:
    - name: lazyload
      kind: lazyload
      enable: true
      general:
        autoPort: true
        autoFence: true
        defaultFence: true   
        wormholePort: # replace to your application service ports, and extend the list in case of multi ports
          - "9080"
      global:
        log:
          logLevel: info
        misc:
          addEnvHeaderViaLua: "true"
          globalSidecarMode: cluster 
          metricSourceType: accesslog
        slimeNamespace: mesh-operator
  component:
    globalSidecar:
    # ignore ..
```
-------

