### PR TITLE
meshreg: fix zk client to use expired local dns records

### DIFF
--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/zookeeper/source.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/zookeeper/source.go
@@ -168,17 +168,19 @@ func (s *Source) reConFunc(reconCh chan<- struct{}) {
 	}
 
 	for {
-		con, _, err := zk.Connect(s.args.Address, time.Duration(s.args.ConnectionTimeout), zk.WithEventCallback(func(ev zk.Event) {
-			if ev.Type != zk.EventDisconnected {
-				return
-			}
+		con, _, err := zk.Connect(s.args.Address, time.Duration(s.args.ConnectionTimeout),
+			zk.WithNoRetryHosts(), // https://github.com/slime-io/go-zk/pull/1
+			zk.WithEventCallback(func(ev zk.Event) {
+				if ev.Type != zk.EventDisconnected {
+					return
+				}
 
-			// notify recon
-			select {
-			case reconCh <- struct{}{}:
-			default:
-			}
-		}))
+				// notify recon
+				select {
+				case reconCh <- struct{}{}:
+				default:
+				}
+			}))
 		if err != nil {
 			log.Infof("re connect zk error %v", err)
 			time.Sleep(time.Second)


### PR DESCRIPTION
when config meshregistry zk source with a k8s service, which recreated after slime has connected to, the zk will use the expired invalid service ip.

also: https://github.com/slime-io/go-zk/pull/1