### PR TITLE
meshreg: notify update only if config actually changes

### DIFF
--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/eureka/conversion.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/eureka/conversion.go
@@ -3,12 +3,12 @@ package eureka
 import (
 	"math"
 	"net"
-	"slime.io/slime/modules/meshregistry/pkg/source"
 	"sort"
 	"strings"
 
 	networking "istio.io/api/networking/v1alpha3"
 
+	"slime.io/slime/modules/meshregistry/pkg/source"
 	"slime.io/slime/modules/meshregistry/pkg/util"
 )
 
@@ -51,6 +51,7 @@ func ConvertServiceEntryMap(
 
 	for _, se := range seMap {
 		source.ApplyServicePortToEndpoints(se)
+		source.RectifyServiceEntry(se)
 	}
 	return seMap, nil
 }

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/eureka/source.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/eureka/source.go
@@ -4,11 +4,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/gogo/protobuf/proto"
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/libistio/pkg/config/event"
 	"istio.io/libistio/pkg/config/resource"
@@ -162,7 +162,7 @@ func (s *Source) refresh() {
 				}
 			}
 		} else {
-			if !reflect.DeepEqual(oldEntry, newEntry) {
+			if !proto.Equal(oldEntry, newEntry) {
 				// UPDATE
 				s.cache[service] = newEntry
 				if event, err := buildEvent(event.Updated, newEntry, service, s.args.ResourceNs); err == nil {

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/nacos/conversion.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/nacos/conversion.go
@@ -3,12 +3,12 @@ package nacos
 import (
 	"math"
 	"net"
-	"slime.io/slime/modules/meshregistry/pkg/source"
 	"sort"
 	"strings"
 
 	networking "istio.io/api/networking/v1alpha3"
 
+	"slime.io/slime/modules/meshregistry/pkg/source"
 	"slime.io/slime/modules/meshregistry/pkg/util"
 )
 
@@ -42,6 +42,7 @@ func ConvertServiceEntryMap(
 
 	for _, se := range seMap {
 		source.ApplyServicePortToEndpoints(se)
+		source.RectifyServiceEntry(se)
 	}
 	return seMap, nil
 }

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/nacos/polling.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/nacos/polling.go
@@ -1,9 +1,9 @@
 package nacos
 
 import (
-	"reflect"
 	"time"
 
+	"github.com/gogo/protobuf/proto"
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/libistio/pkg/config/event"
 )
@@ -80,7 +80,7 @@ func (s *Source) updateServiceInfo() {
 				}
 			}
 		} else {
-			if !reflect.DeepEqual(oldEntry, newEntry) {
+			if !proto.Equal(oldEntry, newEntry) {
 				// UPDATE
 				s.cache[service] = newEntry
 				if event, err := buildEvent(event.Updated, newEntry, service, s.args.ResourceNs, seMetaModifierFactory(service)); err == nil {

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/serviceentry.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/serviceentry.go
@@ -2,15 +2,17 @@ package source
 
 import (
 	"fmt"
-	networking "istio.io/api/networking/v1alpha3"
-	"istio.io/libistio/pkg/config/event"
-	"istio.io/libistio/pkg/config/resource"
-	"istio.io/libistio/pkg/config/schema/collections"
-	"slime.io/slime/modules/meshregistry/pkg/util"
 	"sort"
 	"strings"
 	"sync"
 	"time"
+
+	networking "istio.io/api/networking/v1alpha3"
+	"istio.io/libistio/pkg/config/event"
+	"istio.io/libistio/pkg/config/resource"
+	"istio.io/libistio/pkg/config/schema/collections"
+
+	"slime.io/slime/modules/meshregistry/pkg/util"
 )
 
 var (
@@ -192,4 +194,16 @@ func ApplyServicePortToEndpoints(se *networking.ServiceEntry) {
 
 func PortName(protocol string, num uint32) string {
 	return fmt.Sprintf("%s-%d", strings.ToLower(protocol), num)
+}
+
+func RectifyServiceEntry(se *networking.ServiceEntry) {
+	for _, strs := range [][]string{se.Addresses, se.ExportTo, se.Hosts, se.SubjectAltNames} {
+		sort.SliceStable(strs, func(i, j int) bool { return strs[i] < strs[j] })
+	}
+	sort.SliceStable(se.Endpoints, func(i, j int) bool {
+		return se.Endpoints[i].Address < se.Endpoints[j].Address
+	})
+	sort.SliceStable(se.Ports, func(i, j int) bool {
+		return se.Ports[i].Number < se.Ports[j].Number
+	})
 }

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/serviceentry_test.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/serviceentry_test.go
@@ -1,0 +1,75 @@
+package source
+
+import (
+	"testing"
+
+	"github.com/gogo/protobuf/proto"
+	networking "istio.io/api/networking/v1alpha3"
+)
+
+func TestRectifyServiceEntry(t *testing.T) {
+	type args struct {
+		se          *networking.ServiceEntry
+		rectifiedSe *networking.ServiceEntry
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		{
+			name: "string slice",
+			args: args{
+				se: &networking.ServiceEntry{
+					Hosts:    []string{"foo", "bar"},
+					ExportTo: []string{"ns2", "ns1"},
+				},
+				rectifiedSe: &networking.ServiceEntry{
+					Hosts:    []string{"bar", "foo"},
+					ExportTo: []string{"ns1", "ns2"},
+				},
+			},
+		},
+		{
+			name: "ports",
+			args: args{
+				se: &networking.ServiceEntry{
+					Ports: []*networking.Port{
+						{Number: 81},
+						{Number: 80},
+					},
+				},
+				rectifiedSe: &networking.ServiceEntry{
+					Ports: []*networking.Port{
+						{Number: 80},
+						{Number: 81},
+					},
+				},
+			},
+		},
+		{
+			name: "endpoints",
+			args: args{
+				se: &networking.ServiceEntry{
+					Endpoints: []*networking.WorkloadEntry{
+						{Address: "2.2.2.2"},
+						{Address: "1.1.1.1"},
+					},
+				},
+				rectifiedSe: &networking.ServiceEntry{
+					Endpoints: []*networking.WorkloadEntry{
+						{Address: "1.1.1.1"},
+						{Address: "2.2.2.2"},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			RectifyServiceEntry(tt.args.se)
+			if !proto.Equal(tt.args.se, tt.args.rectifiedSe) {
+				t.Errorf("%s: proto not equal after rectify", tt.name)
+			}
+		})
+	}
+}

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/zookeeper/conversion.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/zookeeper/conversion.go
@@ -7,13 +7,13 @@ import (
 	"net"
 	"net/url"
 	"regexp"
-	"slime.io/slime/modules/meshregistry/pkg/source"
 	"sort"
 	"strconv"
 	"strings"
 
 	networking "istio.io/api/networking/v1alpha3"
 
+	"slime.io/slime/modules/meshregistry/pkg/source"
 	"slime.io/slime/modules/meshregistry/pkg/util"
 )
 
@@ -272,6 +272,7 @@ func convertServiceEntry(
 
 	for _, cse := range serviceEntryByServiceKey {
 		source.ApplyServicePortToEndpoints(cse.se)
+		source.RectifyServiceEntry(cse.se)
 	}
 
 	return serviceEntryByServiceKey

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/zookeeper/model.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/zookeeper/model.go
@@ -1,8 +1,7 @@
 package zookeeper
 
 import (
-	"reflect"
-
+	"github.com/gogo/protobuf/proto"
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/libistio/pkg/config/resource"
 )
@@ -46,16 +45,20 @@ func metadataEquals(m1, m2 resource.Metadata) bool {
 	return true
 }
 
+func (sem ServiceEntryWithMeta) Equals(o ServiceEntryWithMeta) bool {
+	if !metadataEquals(sem.Meta, o.Meta) {
+		return false
+	}
+
+	return proto.Equal(sem.ServiceEntry, o.ServiceEntry)
+}
+
 func (scm SidecarWithMeta) Equals(o SidecarWithMeta) bool {
 	if !metadataEquals(scm.Meta, o.Meta) {
 		return false
 	}
 
-	if !reflect.DeepEqual(scm.Sidecar, o.Sidecar) {
-		return false
-	}
-
-	return true
+	return proto.Equal(scm.Sidecar, o.Sidecar)
 }
 
 type DubboServiceInstance struct {

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/zookeeper/model_test.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/zookeeper/model_test.go
@@ -1,0 +1,83 @@
+package zookeeper
+
+import (
+	"testing"
+
+	networking "istio.io/api/networking/v1alpha3"
+	"istio.io/libistio/pkg/config/resource"
+)
+
+func TestServiceEntryWithMeta_Equals(t *testing.T) {
+	tests := []struct {
+		name string
+		sem  ServiceEntryWithMeta
+		o    ServiceEntryWithMeta
+		want bool
+	}{
+		{
+			name: "different meta version",
+			sem: ServiceEntryWithMeta{
+				ServiceEntry: &networking.ServiceEntry{
+					Hosts: []string{"foo"},
+				},
+				Meta: resource.Metadata{
+					Labels:  resource.StringMap{"foo": "bar"},
+					Version: "v1",
+				},
+			},
+			o: ServiceEntryWithMeta{
+				ServiceEntry: &networking.ServiceEntry{
+					Hosts: []string{"foo"},
+				},
+				Meta: resource.Metadata{
+					Labels:  resource.StringMap{"foo": "bar"},
+					Version: "v2",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "different map order",
+			sem: ServiceEntryWithMeta{
+				ServiceEntry: &networking.ServiceEntry{
+					Hosts: []string{"foo"},
+				},
+				Meta: resource.Metadata{
+					Labels:      resource.StringMap{"hello": "world", "foo": "bar"},
+					Annotations: resource.StringMap{"hello": "world", "foo": "bar"},
+				},
+			},
+			o: ServiceEntryWithMeta{
+				ServiceEntry: &networking.ServiceEntry{
+					Hosts: []string{"foo"},
+				},
+				Meta: resource.Metadata{
+					Labels:      resource.StringMap{"foo": "bar", "hello": "world"},
+					Annotations: resource.StringMap{"foo": "bar", "hello": "world"},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "different serviceEntry",
+			sem: ServiceEntryWithMeta{
+				ServiceEntry: &networking.ServiceEntry{
+					Hosts: []string{"foo"},
+				},
+			},
+			o: ServiceEntryWithMeta{
+				ServiceEntry: &networking.ServiceEntry{
+					Hosts: []string{"bar"},
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.sem.Equals(tt.o); got != tt.want {
+				t.Errorf("ServiceEntryWithMeta.Equals() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/zookeeper/source.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/zookeeper/source.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -486,7 +485,7 @@ func (s *Source) handleServiceData(cacheInUse cmap.ConcurrentMap, provider, cons
 				}
 			}
 		} else if existSeWithMeta, ok := value.(*ServiceEntryWithMeta); ok {
-			if reflect.DeepEqual(existSeWithMeta, newSeWithMeta) {
+			if existSeWithMeta.Equals(*newSeWithMeta) {
 				continue
 			}
 			seCache.Set(serviceKey, newSeWithMeta)


### PR DESCRIPTION
Fix the issue where `ServiceEntryWithMeta` is always judged as not deep-equal, because the new one always has a new timestamp.

https://github.com/slime-io/slime/blob/67380da4891d76f031130eac92b80d95dd0e1a29/staging/src/slime.io/slime/modules/meshregistry/pkg/source/zookeeper/source.go#L450-L463