### PR TITLE
meshregistry: remove arg AggregateDubboMethods and add methods label to zk/cacheJson api

### DIFF
--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/bootstrap/args.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/bootstrap/args.go
@@ -236,7 +236,6 @@ type ZookeeperSourceArgs struct {
 	TrimDubboRemoveDepInterval util.Duration `json:"TrimDubboRemoveDepInterval,omitempty"`
 	// specify how to map `app` to label key:value pair
 	DubboWorkloadAppLabel string `json:"DubboWorkloadAppLabel,omitempty"`
-	AggregateDubboMethods bool   `json:"AggregateDubboMethods,omitempty"` // XXX totally remove this feature?
 
 	// mcp configs
 }


### PR DESCRIPTION
原因：

1. 为了不扰动istio，之前的mr里改为默认不聚合dubbo methods到serviceentry label。 留下一个可选参数做fallback。 但基本无用，所以删除；

2. 存量接口依赖了serviceentry该label，所以给该接口补回该元数据；
