### PR TITLE
lazyload using envoy as global sidecar to support h1/h2

### DIFF
--- a/staging/src/slime.io/slime/modules/lazyload/charts/global-sidecar/templates/cluster-global-sidecar.yaml
+++ b/staging/src/slime.io/slime/modules/lazyload/charts/global-sidecar/templates/cluster-global-sidecar.yaml
@@ -374,10 +374,12 @@ spec:
             - header:
                 key: "Slime-Orig-Dest"
                 value: "%DOWNSTREAM_LOCAL_ADDRESS%"
+              append: false
           {{- if ne $addEnvHeaderViaLua "true" }}
             - header:
                 key: "Slime-Source-Ns"
                 value: "%ENVIRONMENT(POD_NAMESPACE)%"
+              append: false
           {{- end }}
 {{- if eq $addEnvHeaderViaLua "true" }}
     - applyTo: HTTP_FILTER

--- a/staging/src/slime.io/slime/modules/lazyload/charts/global-sidecar/templates/cluster-global-sidecar.yaml
+++ b/staging/src/slime.io/slime/modules/lazyload/charts/global-sidecar/templates/cluster-global-sidecar.yaml
@@ -374,7 +374,6 @@ spec:
             - header:
                 key: "Slime-Orig-Dest"
                 value: "%DOWNSTREAM_LOCAL_ADDRESS%"
-              append: true
           {{- if ne $addEnvHeaderViaLua "true" }}
             - header:
                 key: "Slime-Source-Ns"

--- a/staging/src/slime.io/slime/modules/lazyload/charts/global-sidecar/templates/cluster-global-sidecar.yaml
+++ b/staging/src/slime.io/slime/modules/lazyload/charts/global-sidecar/templates/cluster-global-sidecar.yaml
@@ -57,9 +57,9 @@ apiVersion: networking.istio.io/v1beta1
 kind: DestinationRule
 metadata:
   name: global-sidecar
-  namespace: {{ $ns }}
+  namespace: {{ $clusterGsNamespace }}
 spec:
-  host: global-sidecar.{{ $ns }}.svc.cluster.local
+  host: global-sidecar.{{ $clusterGsNamespace }}.svc.cluster.local
   trafficPolicy:
     connectionPool:
       http:

--- a/staging/src/slime.io/slime/modules/lazyload/charts/global-sidecar/templates/cluster-global-sidecar.yaml
+++ b/staging/src/slime.io/slime/modules/lazyload/charts/global-sidecar/templates/cluster-global-sidecar.yaml
@@ -42,7 +42,7 @@ metadata:
 spec:
   ports:
     {{- range $gsSvcPorts }}
-    - name: http-{{ . }}
+    - name: http2-{{ . }}
       port: {{ int . }}
       protocol: TCP
       targetPort: {{ int . }}
@@ -52,6 +52,18 @@ spec:
   sessionAffinity: None
   type: ClusterIP
 {{- end }}
+---
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: global-sidecar
+  namespace: {{ $ns }}
+spec:
+  host: global-sidecar.{{ $ns }}.svc.cluster.local
+  trafficPolicy:
+    connectionPool:
+      http:
+        useClientProtocol: true
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/staging/src/slime.io/slime/modules/lazyload/charts/global-sidecar/templates/namespace-global-sidecar.yaml
+++ b/staging/src/slime.io/slime/modules/lazyload/charts/global-sidecar/templates/namespace-global-sidecar.yaml
@@ -341,9 +341,11 @@ spec:
             - header:
                 key: "Slime-Orig-Dest"
                 value: "%DOWNSTREAM_LOCAL_ADDRESS%"
+              append: false
             - header:
                 key: "Slime-Source-Ns"
                 value: {{ $ns }}
+              append: false
     - applyTo: VIRTUAL_HOST
       match:
         proxy:

--- a/staging/src/slime.io/slime/modules/lazyload/charts/global-sidecar/templates/namespace-global-sidecar.yaml
+++ b/staging/src/slime.io/slime/modules/lazyload/charts/global-sidecar/templates/namespace-global-sidecar.yaml
@@ -341,11 +341,9 @@ spec:
             - header:
                 key: "Slime-Orig-Dest"
                 value: "%DOWNSTREAM_LOCAL_ADDRESS%"
-              append: true
             - header:
                 key: "Slime-Source-Ns"
                 value: {{ $ns }}
-              append: true
     - applyTo: VIRTUAL_HOST
       match:
         proxy:

--- a/staging/src/slime.io/slime/modules/lazyload/charts/global-sidecar/templates/namespace-global-sidecar.yaml
+++ b/staging/src/slime.io/slime/modules/lazyload/charts/global-sidecar/templates/namespace-global-sidecar.yaml
@@ -41,7 +41,7 @@ metadata:
 spec:
   ports:
     {{- range $gsSvcPorts }}
-    - name: http-{{ . }}
+    - name: http2-{{ . }}
       port: {{ int . }}
       protocol: TCP
       targetPort: {{ int . }}
@@ -51,6 +51,18 @@ spec:
   sessionAffinity: None
   type: ClusterIP
 {{- end }}
+---
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: global-sidecar
+  namespace: {{ $ns }}
+spec:
+  host: global-sidecar.{{ $ns }}.svc.cluster.local
+  trafficPolicy:
+    connectionPool:
+      http:
+        useClientProtocol: true
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/staging/src/slime.io/slime/modules/lazyload/cmd/envoyproxy/Dockerfile
+++ b/staging/src/slime.io/slime/modules/lazyload/cmd/envoyproxy/Dockerfile
@@ -1,0 +1,7 @@
+FROM envoyproxy/envoy:v1.26-latest
+
+WORKDIR /
+
+COPY proxy.yaml . 
+
+ENTRYPOINT ["envoy","-c","./proxy.yaml"]

--- a/staging/src/slime.io/slime/modules/lazyload/cmd/envoyproxy/proxy.yaml
+++ b/staging/src/slime.io/slime/modules/lazyload/cmd/envoyproxy/proxy.yaml
@@ -53,6 +53,8 @@ static_resources:
           use_remote_address: true
           route_config:
             name: proxy 
+            request_headers_to_remove:
+            - "Slime-Orig-Dest"
             virtual_hosts:
             - name: all
               domains:

--- a/staging/src/slime.io/slime/modules/lazyload/cmd/envoyproxy/proxy.yaml
+++ b/staging/src/slime.io/slime/modules/lazyload/cmd/envoyproxy/proxy.yaml
@@ -65,6 +65,33 @@ static_resources:
                 route:
                   cluster: original_dst_cluster 
           http_filters:
+          - name: envoy.filters.http.lua
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
+              default_source_code:
+                inline_string:
+                  function insert_namespace(host, namespace)
+                    if string.find(host, '%.') then
+                      return host
+                    end
+                    if not namespace or namespace == '' then
+                      return host
+                    end
+                    local idx = string.find(host, ':')
+                    if idx then
+                      local prefix = string.sub(host, 1, idx-1)
+                      local suffix = string.sub(host, idx)
+                      return prefix .. "." .. namespace .. suffix
+                    end
+                    return host .. '.' .. namespace
+                  end
+
+                  function envoy_on_request(request_handle)
+                    local sourceNs = request_handle:headers():get("Slime-Source-Ns")
+                    local reqHost = request_handle:headers():get(":authority")
+                    reqHost = insert_namespace(reqHost, sourceNs)
+                    request_handle:headers():replace(":authority", reqHost)
+                  end
           - name: envoy.filters.http.router
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/staging/src/slime.io/slime/modules/lazyload/cmd/envoyproxy/proxy.yaml
+++ b/staging/src/slime.io/slime/modules/lazyload/cmd/envoyproxy/proxy.yaml
@@ -1,0 +1,86 @@
+static_resources:
+  listeners:
+  - address:
+      socket_address:
+        address: 0.0.0.0
+        port_value: 20000
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          access_log:
+          - name: envoy.access_loggers.stdout
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
+          codec_type: AUTO
+          stat_prefix: health 
+          use_remote_address: true
+          route_config:
+            name: health 
+            virtual_hosts:
+            - name: all
+              domains:
+              - "*"
+              routes:
+              - match:
+                  prefix: "/"
+                direct_response:
+                  status: 200
+                  body:
+                    inline_string: "success"
+          http_filters:
+          - name: envoy.filters.http.router
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+  - address:
+      socket_address:
+        address: 0.0.0.0
+        port_value: 80
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          codec_type: AUTO
+          access_log:
+          - name: envoy.access_loggers.stdout
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
+          stat_prefix: egress_http
+          common_http_protocol_options:
+            idle_timeout: 840s
+          use_remote_address: true
+          route_config:
+            name: proxy 
+            virtual_hosts:
+            - name: all
+              domains:
+              - "*"
+              routes:
+              - match:
+                  prefix: "/"
+                route:
+                  cluster: original_dst_cluster 
+          http_filters:
+          - name: envoy.filters.http.router
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+  clusters:
+  - cleanupInterval: 8640000s
+    connectTimeout: 10s
+    lbPolicy: CLUSTER_PROVIDED
+    name: original_dst_cluster 
+    type: ORIGINAL_DST
+    original_dst_lb_config:
+      use_http_header: true
+      http_header_name: "Slime-Orig-Dest"
+    typedExtensionProtocolOptions:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        useDownstreamProtocolConfig:
+          http2ProtocolOptions:
+            maxConcurrentStreams: 1073741824
+          httpProtocolOptions: {}
+
+

--- a/staging/src/slime.io/slime/modules/lazyload/controllers/service_cache.go
+++ b/staging/src/slime.io/slime/modules/lazyload/controllers/service_cache.go
@@ -163,7 +163,8 @@ func isHttp(port corev1.ServicePort) bool {
 		return false
 	}
 	p := strings.Split(port.Name, "-")[0]
-	return PortProtocol(p) == HTTP
+	protocol := PortProtocol(p)
+	return protocol == HTTP || protocol == GRPC || protocol == HTTP2
 }
 
 func updateWormholePort(wormholePort []string, portProtocolCache *PortProtocolCache) ([]string, bool) {

--- a/staging/src/slime.io/slime/modules/lazyload/controllers/serviceentry_cache.go
+++ b/staging/src/slime.io/slime/modules/lazyload/controllers/serviceentry_cache.go
@@ -29,7 +29,7 @@ func (r *ServicefenceReconciler) RegisterSeHandler() {
 func (r *ServicefenceReconciler) cachePort(istioSvcs []*model.Service) {
 	for _, svc := range istioSvcs {
 		for _, port := range svc.Ports {
-			if port.Protocol != model.HTTP {
+			if port.Protocol != model.HTTP && port.Protocol != model.GRPC && port.Protocol != model.HTTP2 {
 				continue
 			}
 			p := int32(port.Port)


### PR DESCRIPTION
lazyload using envoy as global sidecar to support h1/h2. See details on #373.

Close #373 

TODO:
- [X] Support short svc name.
- [ ] Modify example.
- [ ] Modify document.