### PR TITLE
lazyload: fix dispatch before route to global-sidecar

### DIFF
--- a/staging/src/slime.io/slime/modules/lazyload/charts/global-sidecar/templates/cluster-global-sidecar.yaml
+++ b/staging/src/slime.io/slime/modules/lazyload/charts/global-sidecar/templates/cluster-global-sidecar.yaml
@@ -319,7 +319,6 @@ spec:
         value:
           virtual_hosts:
             {{- if $f.dispatches }}
-            {{- $svcPort := . }}
             {{- range $f.dispatches }}
             - domains:
               {{- toYaml .domains | nindent 14 }}
@@ -329,19 +328,18 @@ spec:
                     prefix: /
                   route:
                     {{- if eq .cluster "_GLOBAL_SIDECAR" }}
-                    cluster: outbound|{{$svcPort}}||global-sidecar.{{ $clusterGsNamespace }}.svc.cluster.local
+                    cluster: outbound|{{ $gsPort }}||global-sidecar.{{ $clusterGsNamespace }}.svc.cluster.local
                     timeout: 0s
                     {{- else }}
                     cluster: {{ tpl .cluster $ }}
-              # (dict "fence" $f "dispatch" . "root" $ "Template" (dict "BasePath" "xx"))
                     {{- end }}
             {{- end }}
-            {{- else }}
+            {{- end }}
             - domains:
               - '*'
               name: to_global_sidecar
               routes:
-{{- if (ne $f.disableIpv4Passthrough true) }}
+                {{- if (ne $f.disableIpv4Passthrough true) }}
                 - match:
                     prefix: /
                     headers:
@@ -353,13 +351,12 @@ spec:
                   route:
                     cluster: PassthroughCluster
                     timeout: 0s
-{{- end }}
+                {{- end }}
                 - match:
                     prefix: /
                   route:
                     cluster: outbound|{{ $gsPort }}||global-sidecar.{{ $clusterGsNamespace }}.svc.cluster.local
                     timeout: 0s
-            {{- end }}
           request_headers_to_add:
             - header:
                 key: "Slime-Orig-Dest"

--- a/staging/src/slime.io/slime/modules/lazyload/charts/global-sidecar/templates/namespace-global-sidecar.yaml
+++ b/staging/src/slime.io/slime/modules/lazyload/charts/global-sidecar/templates/namespace-global-sidecar.yaml
@@ -298,7 +298,6 @@ spec:
         value:
           virtual_hosts:
             {{- if $f.dispatches }}
-              {{- $svcPort := . }}
               {{- range $f.dispatches }}
               - domains:
               {{- toYaml .domains | nindent 14 }}
@@ -308,23 +307,33 @@ spec:
                       prefix: /
                     route:
                       {{- if eq .cluster "_GLOBAL_SIDECAR" }}
-                      cluster: outbound|{{$svcPort}}||global-sidecar.{{ $ns }}.svc.cluster.local
+                      cluster: outbound|{{ $gsPort }}||global-sidecar.{{ $ns }}.svc.cluster.local
                       {{- else }}
                       cluster: {{ tpl .cluster $ }}
-                      # (dict "fence" $f "dispatch" . "root" $ "Template" (dict "BasePath" "xx"))
                       {{- end }}
               {{- end }}
-              {{- else }}
               - domains:
                   - '*'
                 name: to_global_sidecar
                 routes:
+                  {{ - if (ne $f.disableIpv4Passthrough true) }}
+                  - match:
+                      prefix: /
+                      headers:
+                        - name: ':authority'
+                          string_match:
+                            safe_regex:
+                              google_re2: { }
+                              regex: '^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(?::([1-9]|[1-9]\d{1,3}|[1-5]\d{4}|6[0-5][0-5][0-3][0-5]))?$'
+                    route:
+                      cluster: PassthroughCluster
+                      timeout: 0s
+                  {{ - end }}
                   - match:
                       prefix: /
                     route:
                       cluster: outbound|{{ $gsPort }}||global-sidecar.{{ $ns }}.svc.cluster.local
                       timeout: 0s
-              {{- end }}
           request_headers_to_add:
             - header:
                 key: "Slime-Orig-Dest"


### PR DESCRIPTION
我们之前支持了 dispatch 特性，即我们可以指定指定某些域名的路由到指定cluster

```yaml
  module:
    - name: lazyload
      kind: lazyload
      enable: true
      general:
        dispatches:
        - name: fake
          domains:
          - "www.163.com"
          - "*.slime.io"  
          cluster: "PassthroughCluster"
        disableIpv4Passthrough: false
        autoPort: true
        autoFence: true
        defaultFence: true   
        wormholePort:
          - "9080"
```


上面slimeboot中描述，我们将www.163.com以及`*.slimeio`的流量直接透传

（修改slimeboot后需要重启slime才能生效）

但是后来支持的ipv4透传功能与dispatch功能有冲突。

------

本次提交使得以下逻辑正常运行：

符合dispatch的流量走passthrough

符合ipv4流量走passthrough

其余匹配不上的流量走兜底


------

需要补充说明的 dispatch 的domains 只支持

精确： `www.foo.com`
前缀： `foo.*`
后缀：`*.foo.com` 




