### PR TITLE
meshreg: support fetching instances from multiple eureka clusters

### DIFF
--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/bootstrap/args.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/bootstrap/args.go
@@ -252,14 +252,19 @@ func (zkArgs *ZookeeperSourceArgs) Validate() error {
 
 type EurekaSourceArgs struct {
 	SourceArgs
-
-	Address []string `json:"Address,omitempty"`
+	EurekaServer
 	// EurekaSource address belongs to nsf or not
 	NsfEureka bool `json:"NsfEureka,omitempty"`
 	// need k8sDomainSuffix in Host
 	K8sDomainSuffix bool `json:"K8SDomainSuffix,omitempty"`
 	// need ns in Host
 	NsHost bool `json:"NsHost,omitempty"`
+
+	Servers []EurekaServer `json:"Servers,omitempty"`
+}
+
+type EurekaServer struct {
+	Address []string `json:"Address,omitempty"`
 }
 
 func (eurekaArgs *EurekaSourceArgs) Validate() error {

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/bootstrap/args.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/bootstrap/args.go
@@ -267,12 +267,25 @@ type EurekaServer struct {
 	Address []string `json:"Address,omitempty"`
 }
 
+func (eurekaServer *EurekaServer) Validate() error {
+	if len(eurekaServer.Address) == 0 {
+		return errors.New("eureka server address must be set")
+	}
+	return nil
+}
+
 func (eurekaArgs *EurekaSourceArgs) Validate() error {
 	if !eurekaArgs.Enabled {
 		return nil
 	}
-	if len(eurekaArgs.Address) == 0 {
-		return errors.New("eureka server address must be set when eureka source is enabled")
+	if len(eurekaArgs.Servers) == 0 {
+		return eurekaArgs.EurekaServer.Validate()
+	}
+	for _, server := range eurekaArgs.Servers {
+		err := server.Validate()
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
same as: https://github.com/slime-io/slime/pull/327

For multiple eureka clusters, we aggregate instances based on service names

Usage:

``` yaml
LEGACY:
  EurekaSource:
    Enabled: true
    Servers:
    # fetch instances from 1.1.1.1
    - Address:  
      - http://1.1.1.1/eureka
    # fetch instances from 2.2.2.2
    - Address:
      - http://2.2.2.2/eureka
    RefreshPeriod: 15s

# compatible with the original configuration
LEGACY:
  EurekaSource:
    Enabled: true
    # fetch instances from 1.1.1.1
    Address:
    - http://1.1.1.1/eureka
    RefreshPeriod: 15s
```