### PR TITLE
plugin:support vhost name without port

### DIFF
--- a/staging/src/slime.io/slime/modules/plugin/controllers/conversion.go
+++ b/staging/src/slime.io/slime/modules/plugin/controllers/conversion.go
@@ -194,9 +194,19 @@ func (r *EnvoyPluginReconciler) translateEnvoyPlugin(cr *v1alpha1.EnvoyPlugin, o
 					cfps := genGatewayCfps(in, cr.Namespace, t, patchCtx, p, m)
 					out.ConfigPatches = append(out.ConfigPatches, cfps...)
 				} else {
-					vhost := &istio.EnvoyFilter_RouteConfigurationMatch_VirtualHostMatch{
-						Name: t.host,
+					host := t.host
+					if patchCtx == istio.EnvoyFilter_SIDECAR_OUTBOUND || patchCtx == istio.EnvoyFilter_GATEWAY {
+						// ':*' is appended if port info is not specified in outbound and gateway
+						// it will match all port in same host after istio adapted
+						if strings.Index(t.host, ":") == -1 {
+							host += ":*"
+						}
 					}
+
+					vhost := &istio.EnvoyFilter_RouteConfigurationMatch_VirtualHostMatch{
+						Name: host,
+					}
+
 					if t.applyTo == istio.EnvoyFilter_HTTP_ROUTE {
 						vhost.Route = &istio.EnvoyFilter_RouteConfigurationMatch_RouteMatch{
 							Name: t.route,


### PR DESCRIPTION
之前的实现中，必须在envoyplugin指定vhost name的全部信息（包括端口）

before:

```yaml
spec:
  host:
  - 163.com:80
```

该pr主要内容：当patch到 outbound 或 gateway时，如果vhostname 没有端口信息，那么就补上一个 ':*'

after:

```yaml
spec:
  host:
  - 163.com
```


result:

```yaml
  - applyTo: VIRTUAL_HOST
    match:
      context: SIDECAR_OUTBOUND
      routeConfiguration:
        vhost:
          name: 163.com:*
    patch:
```

istiod 要做适当适配, 才能支持这个特性

不影响之前使用

