### PR TITLE
plugin:skip port wildcard when plugin host is empty

### DIFF
--- a/staging/src/slime.io/slime/modules/plugin/controllers/conversion.go
+++ b/staging/src/slime.io/slime/modules/plugin/controllers/conversion.go
@@ -198,7 +198,7 @@ func (r *EnvoyPluginReconciler) translateEnvoyPlugin(cr *v1alpha1.EnvoyPlugin, o
 					if patchCtx == istio.EnvoyFilter_SIDECAR_OUTBOUND || patchCtx == istio.EnvoyFilter_GATEWAY {
 						// ':*' is appended if port info is not specified in outbound and gateway
 						// it will match all port in same host after istio adapted
-						if strings.Index(t.host, ":") == -1 {
+						if len(t.host) > 0 && strings.Index(t.host, ":") == -1 {
 							host += ":*"
 						}
 					}


### PR DESCRIPTION
指定route patch插件时,可能存在host为空的情况

所以此时不需要添加 ':*'

相关pr: https://github.com/slime-io/slime/pull/383