### PR TITLE
support setting istio/pkg/log scpoe level

### DIFF
--- a/framework/apis/config/v1alpha1/config.pb.go
+++ b/framework/apis/config/v1alpha1/config.pb.go
@@ -225,15 +225,17 @@ func (m *Global) GetIstioConfigSource() *ConfigSource {
 }
 
 type Log struct {
-	LogLevel             string           `protobuf:"bytes,1,opt,name=logLevel,proto3" json:"logLevel,omitempty"`
-	KlogLevel            int32            `protobuf:"varint,2,opt,name=klogLevel,proto3" json:"klogLevel,omitempty"`
-	LogRotate            bool             `protobuf:"varint,3,opt,name=logRotate,proto3" json:"logRotate,omitempty"`
-	LogRotateConfig      *LogRotateConfig `protobuf:"bytes,4,opt,name=logRotateConfig,proto3" json:"logRotateConfig,omitempty"`
-	EnableQuote          bool             `protobuf:"varint,5,opt,name=enableQuote,proto3" json:"enableQuote,omitempty"`
-	IlogLevel            string           `protobuf:"bytes,6,opt,name=ilogLevel,proto3" json:"ilogLevel,omitempty"`
-	XXX_NoUnkeyedLiteral struct{}         `json:"-"`
-	XXX_unrecognized     []byte           `json:"-"`
-	XXX_sizecache        int32            `json:"-"`
+	LogLevel        string           `protobuf:"bytes,1,opt,name=logLevel,proto3" json:"logLevel,omitempty"`
+	KlogLevel       int32            `protobuf:"varint,2,opt,name=klogLevel,proto3" json:"klogLevel,omitempty"`
+	LogRotate       bool             `protobuf:"varint,3,opt,name=logRotate,proto3" json:"logRotate,omitempty"`
+	LogRotateConfig *LogRotateConfig `protobuf:"bytes,4,opt,name=logRotateConfig,proto3" json:"logRotateConfig,omitempty"`
+	EnableQuote     bool             `protobuf:"varint,5,opt,name=enableQuote,proto3" json:"enableQuote,omitempty"`
+	// define ilog scope level
+	// default:info,xdsc:warn,mcpc:warn
+	IlogLevel            string   `protobuf:"bytes,6,opt,name=ilogLevel,proto3" json:"ilogLevel,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
 }
 
 func (m *Log) Reset()         { *m = Log{} }

--- a/framework/apis/config/v1alpha1/config.proto
+++ b/framework/apis/config/v1alpha1/config.proto
@@ -39,6 +39,8 @@ message Log {
   bool logRotate = 3;
   LogRotateConfig logRotateConfig = 4;
   bool enableQuote = 5;
+  // define ilog scope level
+  // default:info,xdsc:warn,mcpc:warn
   string ilogLevel = 6;
 }
 

--- a/framework/bootstrap/http.go
+++ b/framework/bootstrap/http.go
@@ -7,6 +7,7 @@ import (
 	"net/http/pprof"
 	"slime.io/slime/framework/bootstrap/resource"
 	"strconv"
+	"strings"
 	"sync"
 
 	log "github.com/sirupsen/logrus"
@@ -279,8 +280,23 @@ func iLogLevelHandler() http.Handler {
 				}
 				return
 			}
-			util.SetiLog(level[0])
+
+			scopes := make(map[string]string)
+			if level[0] != "" {
+				log.Infof("get ilog level setting %s", level[0])
+				parts := strings.Split(level[0], ",")
+				for i, _ := range parts {
+					items := strings.Split(parts[i], ":")
+					if len(items) != 2 {
+						continue
+					}
+					scopes[items[0]] = items[1]
+				}
+			}
+
+			util.SetiLog(scopes)
 			log.Infof("ilog level sets to %s successfully", level[0])
+
 			if _, err := w.Write([]byte(fmt.Sprintf("ilog level sets to %s successfully.", level[0]))); err != nil {
 				log.Errorf("write klog level response error, %+v", err)
 			}

--- a/framework/util/util.go
+++ b/framework/util/util.go
@@ -9,9 +9,10 @@ import (
 )
 
 const (
-	slimeLogLevel  = "info"
-	slimeKLogLevel = 5
-	slimeILogLevel = "warn"
+	slimeLogLevel         = "info"
+	slimeKLogLevel        = 5
+	slimeDefaultILogLevel = "info"
+	slimeDefaultScopeName = "default"
 )
 
 var fs *flag.FlagSet


### PR DESCRIPTION
在 https://github.com/slime-io/slime/pull/386 中,  提供了参数动态修改 slime 的 istio/pkg/log

但是之前的实现没有区分scope，也就是全局都会修改

本次mr将提供scope级别的日志等级修改, **默认情况下，所有scope都是info日志**

以下方式将 istio/pkg/log 的scope xdsc和mcpc设置为warn，其余所有scope为info

````yaml
      global:
        log:
          ilogLevel: default:info,xdsc:warn,mcpc:warn
````

或者通过只设置default:info 将所有scope都设置为info

````yaml
      global:
        log:
          ilogLevel: default:info
````

也可以通过接口动态设置日志级别

```
curl  -XPOST 'podip:8081/log/ilog?xdsc:warn,mcpc:warn'
```