### PR TITLE
lazyload proxy use port in host when no OrigDest header

### DIFF
--- a/staging/src/slime.io/slime/modules/lazyload/cmd/proxy/main.go
+++ b/staging/src/slime.io/slime/modules/lazyload/cmd/proxy/main.go
@@ -25,10 +25,11 @@ import (
 )
 
 const (
-	EnvProbePort         = "PROBE_PORT"
-	EnvLogLevel          = "LOG_LEVEL"
-	EnvPodNamespace      = "POD_NAMESPACE"
-	DisableSvcController = "DISABLE_SVC_CONTROLLER"
+	EnvProbePort                   = "PROBE_PORT"
+	EnvLogLevel                    = "LOG_LEVEL"
+	EnvPodNamespace                = "POD_NAMESPACE"
+	EnvDisableSvcController        = "DISABLE_SVC_CONTROLLER"
+	EnvWormHolePortPriorToHostPort = "WORMHOLE_PORT_PRIOR_TO_HOST_PORT"
 )
 
 var (
@@ -38,7 +39,8 @@ var (
 	probePort = os.Getenv(EnvProbePort)
 	logLevel  = os.Getenv(EnvLogLevel)
 
-	disableSvcController = os.Getenv(DisableSvcController) == "true"
+	disableSvcController        = os.Getenv(EnvDisableSvcController) == "true"
+	wormHolePortPriorToHostPort = os.Getenv(EnvWormHolePortPriorToHostPort) == "true"
 
 	configLabelSelector = "lazyload.slime.io/config=global-sidecar"
 
@@ -167,8 +169,9 @@ func startListenAndServe(wormholePorts map[int]struct{}) {
 			srv := &http.Server{
 				Addr: "0.0.0.0" + ":" + strconv.Itoa(whPort),
 				Handler: &proxy.Proxy{
-					WormholePort: whPort,
-					SvcCache:     Cache,
+					WormholePortPriorToHostPort: wormHolePortPriorToHostPort,
+					WormholePort:                whPort,
+					SvcCache:                    Cache,
 				},
 			}
 			servers[whPort] = srv


### PR DESCRIPTION
提高场景兼容性： 当请求没带 orig dest header时，使用host中的port作为转发请求的目标端口 （而不是wormhole port）。 

同时留参数（env WORMHOLE_PORT_PRIOR_TO_HOST_PORT）来保留原来的行为（用于容灾代理而非懒加载场景）