### PR TITLE
meshregistry: add zk/dubbo source arg SelfConsume

### DIFF
--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/bootstrap/args.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/bootstrap/args.go
@@ -193,7 +193,7 @@ type InstanceMetaRelabelItem struct {
 	// TargetKey is the new key to be added to the instance metadata based on the original key.
 	TargetKey string `json:"TargetKey,omitempty"`
 	// Whether to overwrite the value of the TargetKey if it already exists in the instance metadata.
-	Overwirte bool `json:"Overwirte,omitempty"`
+	Overwrite bool `json:"Overwrite,omitempty"`
 	// ValuesMapping is a map that associates values of the Key to values of the TargetKey.
 	// If the Key's value is found in the map, the corresponding value is used for the TargetKey.
 	// If not, the original value is used for the TargetKey.
@@ -236,6 +236,8 @@ type ZookeeperSourceArgs struct {
 	TrimDubboRemoveDepInterval util.Duration `json:"TrimDubboRemoveDepInterval,omitempty"`
 	// specify how to map `app` to label key:value pair
 	DubboWorkloadAppLabel string `json:"DubboWorkloadAppLabel,omitempty"`
+	// if true, will consider self-provided services as consumed services and add them to `Sidecar`
+	SelfConsume bool `json:"SelfConsume,omitempty"`
 
 	// mcp configs
 }

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/nacos/source.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/nacos/source.go
@@ -389,7 +389,7 @@ func reGroupInstances(rl *bootstrap.InstanceMetaRelabel,
 							v = nv
 						}
 					}
-					if _, exist := inst.Metadata[item.TargetKey]; !exist || item.Overwirte {
+					if _, exist := inst.Metadata[item.TargetKey]; !exist || item.Overwrite {
 						inst.Metadata[item.TargetKey] = v
 					}
 				}


### PR DESCRIPTION
为meshregistry dubbo/zk source增加`SelfConsume`参数，用于场景： 特殊情况下可能dubbo应用会调用自己提供的服务，而这个依赖关系又没有上报到zk（consume信息）导致meshregistry无法拿到。

该参数设为`true`后，会自动把app提供的服务添加到自己的依赖关系中，也即生成的`Sidecar`资源中。
