### PR TITLE
mv request_header_to_add to route level

### DIFF
--- a/staging/src/slime.io/slime/modules/lazyload/charts/global-sidecar/templates/cluster-global-sidecar.yaml
+++ b/staging/src/slime.io/slime/modules/lazyload/charts/global-sidecar/templates/cluster-global-sidecar.yaml
@@ -342,12 +342,23 @@ spec:
                 - match:
                     prefix: /
                   route:
-                    {{- if eq .cluster "_GLOBAL_SIDECAR" }}
-                    cluster: outbound|{{ $gsPort }}||global-sidecar.{{ $clusterGsNamespace }}.svc.cluster.local
-                    {{- else }}
-                    cluster: {{ tpl .cluster $ }}
-                    {{- end }}
                     timeout: 0s
+                  {{- if eq .cluster "_GLOBAL_SIDECAR" }}
+                    cluster: outbound|{{ $gsPort }}||global-sidecar.{{ $clusterGsNamespace }}.svc.cluster.local
+                  request_headers_to_add:
+                    - header:
+                        key: "Slime-Orig-Dest"
+                        value: "%DOWNSTREAM_LOCAL_ADDRESS%"
+                      append: false
+                    {{- if ne $addEnvHeaderViaLua true }}
+                    - header:
+                        key: "Slime-Source-Ns"
+                        value: "%ENVIRONMENT(POD_NAMESPACE)%"
+                      append: false
+                    {{- end }}
+                  {{- else }}
+                    cluster: {{ tpl .cluster $ }}
+                  {{- end }}
             {{- end }}
             {{- end }}
             {{- end }}
@@ -367,35 +378,46 @@ spec:
                           google_re2: {}
                           regex: {{ .domainRegex }}
                   route:
+                    timeout: 0s
                     {{- if eq .cluster "_GLOBAL_SIDECAR" }}
                     cluster: outbound|{{ $gsPort }}||global-sidecar.{{ $clusterGsNamespace }}.svc.cluster.local
+                  request_headers_to_add:
+                    - header:
+                        key: "Slime-Orig-Dest"
+                        value: "%DOWNSTREAM_LOCAL_ADDRESS%"
+                      append: false
+                    {{- if ne $addEnvHeaderViaLua true }}
+                    - header:
+                        key: "Slime-Source-Ns"
+                        value: "%ENVIRONMENT(POD_NAMESPACE)%"
+                      append: false
+                    {{- end }}
                     {{- else }}
                     cluster: {{ tpl .cluster $ }}
                     {{- end }}
-                    timeout: 0s
                 {{- end }}
                 {{- end }}
                 {{- end }}
                 - match:
                     prefix: /
                   route:
+                    timeout: 0s
                     {{- if $passthroughByDefault }}
                     cluster: PassthroughCluster
                     {{- else }}
                     cluster: outbound|{{ $gsPort }}||global-sidecar.{{ $clusterGsNamespace }}.svc.cluster.local
+                  request_headers_to_add:
+                    - header:
+                        key: "Slime-Orig-Dest"
+                        value: "%DOWNSTREAM_LOCAL_ADDRESS%"
+                      append: false
+                    {{- if ne $addEnvHeaderViaLua true }}
+                    - header:
+                        key: "Slime-Source-Ns"
+                        value: "%ENVIRONMENT(POD_NAMESPACE)%"
+                      append: false
                     {{- end }}
-                    timeout: 0s
-          request_headers_to_add:
-            - header:
-                key: "Slime-Orig-Dest"
-                value: "%DOWNSTREAM_LOCAL_ADDRESS%"
-              append: false
-          {{- if ne $addEnvHeaderViaLua true }}
-            - header:
-                key: "Slime-Source-Ns"
-                value: "%ENVIRONMENT(POD_NAMESPACE)%"
-              append: false
-          {{- end }}
+                    {{- end }}
 {{- if eq $addEnvHeaderViaLua true }}
     - applyTo: HTTP_FILTER
       match:

--- a/staging/src/slime.io/slime/modules/lazyload/charts/global-sidecar/templates/namespace-global-sidecar.yaml
+++ b/staging/src/slime.io/slime/modules/lazyload/charts/global-sidecar/templates/namespace-global-sidecar.yaml
@@ -317,12 +317,21 @@ spec:
                   - match:
                       prefix: /
                     route:
+                      timeout: 0s
                       {{- if eq .cluster "_GLOBAL_SIDECAR" }}
                       cluster: outbound|{{ $gsPort }}||global-sidecar.{{ $ns }}.svc.cluster.local
+                    request_headers_to_add:
+                      - header:
+                          key: "Slime-Orig-Dest"
+                          value: "%DOWNSTREAM_LOCAL_ADDRESS%"
+                        append: false
+                      - header:
+                          key: "Slime-Source-Ns"
+                          value: {{ $ns }}
+                        append: false
                       {{- else }}
                       cluster: {{ tpl .cluster $ }}
                       {{- end }}
-                      timeout: 0s
               {{- end }}
               {{- end }}
               {{- end }}
@@ -342,33 +351,42 @@ spec:
                               google_re2: {}
                               regex: {{ .domainRegex }}
                     route:
+                      timeout: 0s
                       {{- if eq .cluster "_GLOBAL_SIDECAR" }}
                       cluster: outbound|{{ $gsPort }}||global-sidecar.{{ $ns }}.svc.cluster.local
+                    request_headers_to_add:
+                      - header:
+                          key: "Slime-Orig-Dest"
+                          value: "%DOWNSTREAM_LOCAL_ADDRESS%"
+                        append: false
+                      - header:
+                          key: "Slime-Source-Ns"
+                          value: {{ $ns }}
+                        append: false
                       {{- else }}
                       cluster: {{ tpl .cluster $ }}
                       {{- end }}
-                      timeout: 0s
                   {{- end }}
                   {{- end }}
                   {{- end }}
                   - match:
                       prefix: /
                     route:
+                      timeout: 0s
                       {{- if $passthroughByDefault }}
                       cluster: PassthroughCluster
                       {{- else }}
                       cluster: outbound|{{ $gsPort }}||global-sidecar.{{ $ns }}.svc.cluster.local
+                    request_headers_to_add:
+                      - header:
+                          key: "Slime-Orig-Dest"
+                          value: "%DOWNSTREAM_LOCAL_ADDRESS%"
+                        append: false
+                      - header:
+                          key: "Slime-Source-Ns"
+                          value: {{ $ns }}
+                        append: false
                       {{- end }}
-                      timeout: 0s
-          request_headers_to_add:
-            - header:
-                key: "Slime-Orig-Dest"
-                value: "%DOWNSTREAM_LOCAL_ADDRESS%"
-              append: false
-            - header:
-                key: "Slime-Source-Ns"
-                value: {{ $ns }}
-              append: false
     - applyTo: VIRTUAL_HOST
       match:
         proxy:


### PR DESCRIPTION
之前的 `request_header_to_add` 加在了rc级别 [rc](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route.proto)

这就导致了给rc下的所有路由都加上了这些headers

而我们本意是只给发往 global-sidecar 的流量加上header

参考 [route](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#envoy-v3-api-msg-config-route-v3-route)