### PR TITLE
lazyload: remove ISTIO_META_ISTIO_VERSION from gs when accesslog is used

### DIFF
--- a/staging/src/slime.io/slime/modules/lazyload/charts/global-sidecar/templates/cluster-global-sidecar.yaml
+++ b/staging/src/slime.io/slime/modules/lazyload/charts/global-sidecar/templates/cluster-global-sidecar.yaml
@@ -170,8 +170,10 @@ spec:
           proxyMetadata:
             ISTIO_META_SLIME_APP:
               LAZYLOAD_GLOBAL_SIDECAR
+        {{- if ne (default "" $f.metricSourceType) "accesslog" }}
             ISTIO_META_ISTIO_VERSION:
               "999.0.0"
+        {{- end }}
         {{- if eq (default "accesslog" $f.metricSourceType) "accesslog" }}
         sidecar.istio.io/bootstrapOverride: "lazyload-accesslog-source"
         {{- end }}

--- a/staging/src/slime.io/slime/modules/lazyload/charts/global-sidecar/templates/namespace-global-sidecar.yaml
+++ b/staging/src/slime.io/slime/modules/lazyload/charts/global-sidecar/templates/namespace-global-sidecar.yaml
@@ -144,8 +144,10 @@ spec:
           proxyMetadata:
             ISTIO_META_SLIME_APP:
               LAZYLOAD_GLOBAL_SIDECAR
+          {{- if ne (default "" $f.metricSourceType) "accesslog" }}
             ISTIO_META_ISTIO_VERSION:
               "999.0.0"
+          {{- end }}
         {{- if eq (default "accesslog" $f.metricSourceType) "accesslog" }}
         sidecar.istio.io/bootstrapOverride: "lazyload-accesslog-source"
         {{- end }}


### PR DESCRIPTION
由于社区版本1.13以及之后会下发 stats-filter envoyfilter， 这影响了prometheus方式的lazyload获取指标

所以给global-sidecar加了 `ISTIO_META_ISTIO_VERSION: 999.0.0`, 表示不需要下发这些stats-filter至global-sidecar

---

如果懒加载采用accesslog方式，就不必加上 `ISTIO_META_ISTIO_VERSION: 999.0.0`
