### PR TITLE
plugin: envoyplugin support wasm/rider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,6 @@ staging/src/slime.io/slime/modules/*/.idea/*
 ### module helm chats ###
 boot/helm-charts/slimeboot/templates/modules/*
 
+### netease ###
+/efficiency.json
+

--- a/staging/src/slime.io/slime/modules/plugin/controllers/proto.go
+++ b/staging/src/slime.io/slime/modules/plugin/controllers/proto.go
@@ -1,0 +1,84 @@
+package controllers
+
+import "github.com/gogo/protobuf/types"
+
+func addStructField(s *types.Struct, k string, value *types.Value) *types.Struct {
+	s.Fields[k] = value
+	return s
+}
+
+func structToValue(st *types.Struct) *types.Value {
+	return &types.Value{
+		Kind: &types.Value_StructValue{
+			StructValue: st,
+		},
+	}
+}
+
+func stringToValue(s string) *types.Value {
+	return &types.Value{
+		Kind: &types.Value_StringValue{
+			StringValue: s,
+		},
+	}
+}
+
+type structWrapper struct {
+	st *types.Struct
+}
+
+func (s *structWrapper) AddField(k string, value *types.Value) *structWrapper {
+	s.st.Fields[k] = value
+	return s
+}
+
+func (s *structWrapper) AddStructField(k string, st *types.Struct) *structWrapper {
+	return s.AddField(k, structToValue(st))
+}
+
+func (s *structWrapper) WrapToStruct(k string) *structWrapper {
+	return newStructWrapper(nil).AddStructField(k, s.st)
+}
+
+func (s *structWrapper) WrapToListValue() *types.Value {
+	return &types.Value{
+		Kind: &types.Value_ListValue{
+			ListValue: &types.ListValue{
+				Values: []*types.Value{
+					structToValue(s.st),
+				},
+			},
+		},
+	}
+}
+
+func (s *structWrapper) AddStringField(k string, v string) *structWrapper {
+	return s.AddField(k, stringToValue(v))
+}
+
+func (s *structWrapper) Get() *types.Struct {
+	return s.st
+}
+
+func newStructWrapper(st *types.Struct) *structWrapper {
+	if st == nil {
+		st = &types.Struct{Fields: map[string]*types.Value{}}
+	}
+	return &structWrapper{st: st}
+}
+
+func fieldToStruct(k string, value *types.Value) *types.Struct {
+	return &types.Struct{
+		Fields: map[string]*types.Value{
+			k: value,
+		},
+	}
+}
+
+func wrapStructToStruct(k string, st *types.Struct) *types.Struct {
+	return fieldToStruct(k, structToValue(st))
+}
+
+func wrapStructToStructWrapper(k string, st *types.Struct) *structWrapper {
+	return newStructWrapper(nil).AddStructField(k, st)
+}


### PR DESCRIPTION

使用方式如下：

```yaml
# namespace: ns1
  - enable: true
    name: fault-injection
    rider:
      settings:
        delay:
          delaySwitch: true
          delayTime: 3000
        error:
          errorSwitch: false
    typeUrl: type.googleapis.com/proxy.filters.http.rider.v3alpha1.RouteFilterConfig
  - enable: true
    name: fault-injection
    typeUrl: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.RoutePluginConfig
    wasm:
      settings:
        blockRules:
        - .*
        caseInsensitive: false
        rejectedCode: "422"
```

输出envoyfilter如下：

```yaml
  - applyTo: HTTP_ROUTE
    match:
      context: SIDECAR_OUTBOUND
      routeConfiguration:
        vhost:
          name: nsf-demo-stock-viewer-sidecar.skiff-nsfdemo-sidecar.svc.cluster.local:80
          route:
            name: myroute
    patch:
      operation: MERGE
      value:
        typedPerFilterConfig:
          ns1.fault-injection.rider:
            '@type': type.googleapis.com/udpa.type.v1.TypedStruct
            type_url: type.googleapis.com/proxy.filters.http.rider.v3alpha1.RouteFilterConfig
            value:
              plugins:
              - config:
                  delay:
                    delaySwitch: true
                    delayTime: 3000
                  error:
                    errorSwitch: false
                name: fault-injection
  - applyTo: HTTP_ROUTE
    match:
      context: SIDECAR_OUTBOUND
      routeConfiguration:
        vhost:
          name: nsf-demo-stock-viewer-sidecar.skiff-nsfdemo-sidecar.svc.cluster.local:80
          route:
            name: myroute
    patch:
      operation: MERGE
      value:
        typedPerFilterConfig:
          ns1.fault-injection:
            '@type': type.googleapis.com/udpa.type.v1.TypedStruct
            type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.RoutePluginConfig
            value:
              configuration:
                '@type': type.googleapis.com/google.protobuf.StringValue
                value: '{"blockRules":[".*"],"caseInsensitive":false,"rejectedCode":"422"}'
```
