### PR TITLE
Optimize meshreg’s CPU usage and boundary scene adaptation

### DIFF
--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/zookeeper/watching.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/zookeeper/watching.go
@@ -186,6 +186,7 @@ func (ew *EndpointWatcher) simpleWatch(path string, ch chan simpleWatchItem) {
 			err:  err,
 		}:
 			if first && err != nil { // especially for the first watch failure
+				first = false
 				// When the err is not nil, the eventCh will be nil, need to redo watch,
 				break
 			}

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/util/cache/podCache.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/util/cache/podCache.go
@@ -74,7 +74,11 @@ func (pc *podCache) add(obj interface{}) {
 	if ok {
 		ip := pod.Status.PodIP
 		if ip == "" {
-			// log.Warnf("pod %s has no ip when add", pod.Name)
+			// log.Warnf("pod %s/%s has no ip when add", pod.Namespace, pod.Name)
+			return
+		}
+		if pod.Status.Phase != v1.PodRunning {
+			// log.Warnf("pod %s/%s is not running when add", pod.Namespace, pod.Name)
 			return
 		}
 		pc.cache.Set(ip, &podWrapper{&pod.ObjectMeta, pod.Spec.NodeName})
@@ -86,7 +90,11 @@ func (pc *podCache) update(oldObj, newObj interface{}) {
 	if ok {
 		ip := pod.Status.PodIP
 		if ip == "" {
-			// log.Warnf("pod %s has no ip when update", pod.Name)
+			// log.Warnf("pod %s/%s has no ip when update", pod.Namespace, pod.Name)
+			return
+		}
+		if pod.Status.Phase != v1.PodRunning {
+			// log.Warnf("pod %s/%s is not running when update", pod.Namespace, pod.Name)
 			return
 		}
 		pc.cache.Set(ip, &podWrapper{&pod.ObjectMeta, pod.Spec.NodeName})
@@ -98,7 +106,7 @@ func (pc *podCache) delete(obj interface{}) {
 	if ok {
 		ip := pod.Status.PodIP
 		if ip == "" {
-			// log.Warnf("pod %s has no ip when delete", pod.Name)
+			// log.Warnf("pod %s/%s has no ip when delete", pod.Namespace, pod.Name)
 			return
 		}
 		pc.cache.Remove(ip)


### PR DESCRIPTION
1. Fix meshreg's performance degradation:
    in [mr388](https://github.com/slime-io/slime/pull/388) we fixed a bug that would cause the program to hang. However, in some scenarios (for example, providers or consumers nodes do not exist), the first watch for zk ep will fail, bypassing the retry backoff strategy, and frequent retries will eventually occupy a lot of CPU. 
2. boundary scene adaptation:
    meshreg will collect pod information in the cluster and populate the pod label into the metadata of the service instance with the same IP as the pod according to the source configuration. However, in clusters, there may be situations where non-running pods are assigned IP addresses but are not recycled, causing the IP-based matching mechanism to be ineffective.