### PR TITLE
meshreg: mv update-resource-version from convert func to McpConfigStore.Update to avoid possible race condition

### DIFF
--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/mcpoverxds/mcpcontroller.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/mcpoverxds/mcpcontroller.go
@@ -384,13 +384,9 @@ func (c *McpController) convert(e event.Event) (*mcpmodel.Config, string, string
 
 	var (
 		gvk = resource.TypeUrlToGvk(e.Source.Resource().GroupVersionKind().String())
-		ver = e.Resource.Metadata.Version
+		ver resource2.Version
 	)
-	if source.IsInternalResource(gvk) {
-		c.verMut.Lock()
-		ver = resource2.Version(time.Now().String())
-		c.verMut.Unlock()
-	} else {
+	if !source.IsInternalResource(gvk) {
 		k8sVer, err := strconv.ParseUint(string(ver), 10, 64)
 		if err != nil {
 			return nil, "", "", fmt.Errorf("k8s resource event %v version %v not uint", e.Resource.Metadata, ver)
@@ -413,10 +409,7 @@ func (c *McpController) convert(e event.Event) (*mcpmodel.Config, string, string
 		Spec:       e.Resource.Message,
 	}
 
-	if c.mcpArgs.EnableAnnoResVer {
-		if meta.ResourceVersion == "" {
-			return nil, "", "", fmt.Errorf("res ver empty but anno res ver enabled")
-		}
+	if c.mcpArgs.EnableAnnoResVer && meta.ResourceVersion != "" {
 		conf.UpdateAnnotationResourceVersion()
 	}
 


### PR DESCRIPTION
原来： 

1. convert中更新resourceversion然后Update；
2. 但event-update-config流程可能被不同source并发调用，特殊时序下可能导致 **先convert生成较低ver的后update**，从而导致 configstore中的configs的maxver不是单调递增的，从而可能出现 **以较大ver触发的推送中不包含较小ver的数据**；

修复： 在update中更新ver，保证configstore中的configs的maxver单调递增的，修复该问题。
