### PR TITLE
limiter: fix matching order problem

### DIFF
--- a/staging/src/slime.io/slime/modules/limiter/controllers/envoy_global_limit.go
+++ b/staging/src/slime.io/slime/modules/limiter/controllers/envoy_global_limit.go
@@ -176,11 +176,11 @@ func generateGlobalRateLimitDescriptor(descriptors []*microservicev1alpha2.Smart
 			// if header match and querymatch both exist, generate it by request header and query
 			if useHeader && useQuery {
 				headerItem := &model.Descriptor{}
-				headerItem.Key = model.HeaderValueMatch
+				headerItem.Key = model.QueryMatch
 				headerItem.Value = generateDescriptorValue(descriptor, loc)
 				headerItem.Descriptors = []model.Descriptor{
 					{
-						Key:         model.QueryMatch,
+						Key:         model.HeaderValueMatch,
 						Value:       generateDescriptorValue(descriptor, loc),
 						RateLimit:   ratelimit,
 						Descriptors: nil,


### PR DESCRIPTION
复杂场景下，给全局共享限流同时配置：header match 和 query match时

（先配置query match 再配置 query match）导致全局共享限流不生效
