### PR TITLE
framework: fix npe when cfg is missing

### DIFF
--- a/framework/model/module/module.go
+++ b/framework/model/module/module.go
@@ -145,7 +145,7 @@ func (rm *moduleReadyManager) check() error {
 
 func LoadModule(name string, modGetter func(modCfg *bootconfig.Config) Module, bundleConfig *bootconfig.Config) (Module, *bootstrap.ParsedModuleConfig, error) {
 	pmCfg, err := bootstrap.GetModuleConfig(name)
-	if err != nil {
+	if err != nil || pmCfg == nil {
 		return nil, nil, err
 	}
 
@@ -226,6 +226,10 @@ func Main(bundle string, modules []Module) {
 	mainMod, mainModParsedCfg, err := LoadModule("", modGetter, nil)
 	if err != nil {
 		panic(err)
+	}
+	if mainMod == nil {
+		log.Error("main mod nil")
+		fatal()
 	}
 	mainModConfig, mainModRawJson, mainModGeneralJson := mainModParsedCfg.Config,
 		mainModParsedCfg.RawJson, mainModParsedCfg.GeneralJson


### PR DESCRIPTION
slime启动时会从 /etc/slime/config 目录下读取配置

如果配置不存在, 则交给framework判断，并退出