### PR TITLE
lazyload: fix incorrect deletion behavior when pod relate to multi sevice

### DIFF
--- a/staging/src/slime.io/slime/modules/lazyload/controllers/service_cache.go
+++ b/staging/src/slime.io/slime/modules/lazyload/controllers/service_cache.go
@@ -431,7 +431,10 @@ func (r *ServicefenceReconciler) deleteIpFromEp(ep *corev1.Endpoints) {
 	// delete ips related svc
 	ipToSvcCache.Lock()
 	for _, ip := range ips {
-		delete(ipToSvcCache.Data, ip)
+		// ip maybe related to different svc
+		if _, ok := ipToSvcCache.Data[ip]; ok {
+			delete(ipToSvcCache.Data[ip], svc)
+		}
 	}
 	ipToSvcCache.Unlock()
 }


### PR DESCRIPTION
多个service选中同一个pods的场景下

其中一个服务对应endpoints的更新，将导致ip绑定的多个svc缓存清空（采用 delete + add 进行update操作）

导致只有一个service对应的sidecar被更新



