### PR TITLE
meshreg: add metrics

### DIFF
--- a/framework/monitoring/monitoring.go
+++ b/framework/monitoring/monitoring.go
@@ -2,14 +2,18 @@ package monitoring
 
 import (
 	"fmt"
+
 	"istio.io/pkg/monitoring"
 )
 
-var (
-	SubModulesCount = monitoring.NewGauge(
-		"framework_submodules_count",
-		"total number of submodules",
-	)
+const (
+	UnitSeconds      = "s"
+	UnitMilliseconds = "ms"
+)
+
+var SubModulesCount = monitoring.NewGauge(
+	"framework_submodules_count",
+	"total number of submodules",
 )
 
 func init() {
@@ -30,10 +34,20 @@ func NewSum(module string, name string, help string, options ...monitoring.Optio
 	return sum
 }
 
+func NewDistribution(module string, name string, help string, bounds []float64, options ...monitoring.Options) monitoring.Metric {
+	histogram := monitoring.NewDistribution(fmt.Sprintf("%s_%s", module, name), help, bounds, options...)
+	monitoring.MustRegister(histogram)
+	return histogram
+}
+
 func MustCreateLabel(key string) monitoring.Label {
 	return monitoring.MustCreateLabel(key)
 }
 
-func WithLabels(resourceName monitoring.Label) monitoring.Options {
-	return monitoring.WithLabels(resourceName)
+func WithLabels(resourceName ...monitoring.Label) monitoring.Options {
+	return monitoring.WithLabels(resourceName...)
+}
+
+func WithUnit(unit string) monitoring.Options {
+	return monitoring.WithUnit(monitoring.Unit(unit))
 }

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/mcpoverxds/mcpcontroller.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/mcpoverxds/mcpcontroller.go
@@ -25,6 +25,7 @@ import (
 	frameworkmodel "slime.io/slime/framework/model"
 	"slime.io/slime/modules/meshregistry/model"
 	"slime.io/slime/modules/meshregistry/pkg/bootstrap"
+	"slime.io/slime/modules/meshregistry/pkg/monitoring"
 	"slime.io/slime/modules/meshregistry/pkg/source"
 )
 
@@ -316,6 +317,7 @@ func (c *McpController) push() {
 	log.Infof("new push for version: %s", version)
 	c.mcpServer.NotifyPush(req)
 	c.lastPushVer = version
+	monitoring.RecordMcpPush()
 }
 
 func (c *McpController) start(ctx context.Context) {

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/monitoring/monitoring.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/monitoring/monitoring.go
@@ -1,0 +1,55 @@
+package monitoring
+
+import (
+	"time"
+
+	"slime.io/slime/framework/monitoring"
+	"slime.io/slime/modules/meshregistry/model"
+)
+
+var (
+	// souceLabel is the label for the source of the service entry.
+	souceLabel = monitoring.MustCreateLabel("source")
+	// statusLabel is the label for the status of the event.
+	statusLabel = monitoring.MustCreateLabel("status")
+)
+
+var (
+
+	// enabledSource is the number of enabled sources.
+	enabledSource = monitoring.NewGauge(
+		model.ModuleName,
+		"enabled_source",
+		"Number of enabled sources.",
+	)
+
+	// readyTime is the time spent on ready in seconds.
+	readyTime = monitoring.NewGauge(
+		model.ModuleName,
+		"ready_time",
+		"Time spent on ready in seconds",
+		monitoring.WithLabels(souceLabel),
+	)
+
+	// mcpPushCount is the number of mcp push.
+	mcpPushCount = monitoring.NewSum(
+		model.ModuleName,
+		"mcp_push_count",
+		"Number of mcp push.",
+	)
+)
+
+// RecordEnabledSource records the number of enabled sources.
+func RecordEnabledSource(count int) {
+	enabledSource.Record(float64(count))
+}
+
+// RecordReady records the time spent on ready.
+func RecordReady(source string, t0, t1 time.Time) {
+	readyTime.With(souceLabel.Value(source)).Record(float64(t1.Sub(t0).Seconds()))
+}
+
+// RecordMcpPush records the number of mcp push.
+func RecordMcpPush() {
+	mcpPushCount.Increment()
+}

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/monitoring/source.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/monitoring/source.go
@@ -1,0 +1,212 @@
+package monitoring
+
+import (
+	"fmt"
+	"time"
+
+	"istio.io/libistio/pkg/config/event"
+
+	"slime.io/slime/framework/bootstrap/collections"
+	"slime.io/slime/framework/monitoring"
+	"slime.io/slime/modules/meshregistry/model"
+)
+
+var (
+	// configTypeLabel is the label for the type of the config.
+	configTypeLabel = monitoring.MustCreateLabel("config_type")
+
+	servceEntryType = collections.IstioNetworkingV1Alpha3Serviceentries.String()
+	sidecarType     = collections.IstioNetworkingV1Alpha3Sidecars.String()
+)
+
+var (
+	// pollingTime is the time spent on polling in seconds.
+	pollingTime = monitoring.NewDistribution(
+		model.ModuleName,
+		"polling_time",
+		"Time spent on polling in seconds",
+		[]float64{.5, 1, 3, 5, 8, 10, 20, 30, 60, 90, 120},
+		monitoring.WithLabels(souceLabel, statusLabel),
+		monitoring.WithUnit(monitoring.UnitSeconds),
+	)
+	// pollingsCount is the number of pollings by source.
+	pollingsCount = monitoring.NewSum(
+		model.ModuleName,
+		"pollings_count",
+		"Number of pollings by source.",
+		monitoring.WithLabels(souceLabel, statusLabel),
+	)
+
+	// serviceEntryTotal is the number of service entries in the mesh registry by source.
+	serviceEntryTotal = monitoring.NewSum(
+		model.ModuleName,
+		"service_entry_total",
+		"Number of service entries in the mesh registry by source.",
+		monitoring.WithLabels(souceLabel),
+	)
+	// serviceEntryCreation is the number of service entries created by source.
+	serviceEntryCreation = monitoring.NewSum(
+		model.ModuleName,
+		"service_entry_creation",
+		"Number of service entries created by source.",
+		monitoring.WithLabels(souceLabel),
+	)
+	// serviceEntryDeletion is the number of service entries deleted by source.
+	serviceEntryDeletion = monitoring.NewSum(
+		model.ModuleName,
+		"service_entry_deletion",
+		"Number of service entries deleted by source,"+
+			" or the endpoints of service entry are cleared.",
+		monitoring.WithLabels(souceLabel),
+	)
+	// serviceEntryUpdate is the number of service entries updated by source.
+	serviceEntryUpdate = monitoring.NewSum(
+		model.ModuleName,
+		"service_entry_update",
+		"Number of service entries updated by source.",
+		monitoring.WithLabels(souceLabel),
+	)
+
+	// sidecarTotal is the number of sidecars in the mesh registry by source.
+	sidecarTotal = monitoring.NewSum(
+		model.ModuleName,
+		"sidecar_total",
+		"Number of sidecars in the mesh registry by source.",
+		monitoring.WithLabels(souceLabel),
+	)
+
+	// sidecarCreation is the number of sidecars created by source.
+	sidecarCreation = monitoring.NewSum(
+		model.ModuleName,
+		"sidecar_creation",
+		"Number of sidecars created by source.",
+		monitoring.WithLabels(souceLabel),
+	)
+	// sidecarDeletion is the number of sidecars deleted by source.
+	sidecarDeletion = monitoring.NewSum(
+		model.ModuleName,
+		"sidecar_deletion",
+		"Number of sidecars deleted by source.",
+		monitoring.WithLabels(souceLabel),
+	)
+	// sidecarUpdate is the number of sidecars updated by source.
+	sidecarUpdate = monitoring.NewSum(
+		model.ModuleName,
+		"sidecar_update",
+		"Number of sidecars updated by source.",
+		monitoring.WithLabels(souceLabel),
+	)
+
+	// sourceEventTypeLabel is the label for the type of the source event.
+	sourceEventTypeLabel = monitoring.MustCreateLabel("event_type")
+	// sourceEventCount is the number of events by source.
+	sourceEventCount = monitoring.NewSum(
+		model.ModuleName,
+		"source_event_count",
+		"config event count by source, with event type and config type, and status.",
+		monitoring.WithLabels(souceLabel, configTypeLabel, sourceEventTypeLabel, statusLabel),
+	)
+
+	// sourceClientRequestCount is the number of client requests by source, with status.
+	sourceClientRequestCount = monitoring.NewSum(
+		model.ModuleName,
+		"source_client_request_count",
+		"client request count by source, with status.",
+		monitoring.WithLabels(souceLabel, statusLabel),
+	)
+)
+
+// RecordPolling records the time spent on each polling and increment the number of pollings by source.
+func RecordPolling(source string, t0, t1 time.Time, success bool) {
+	pollingTime.With(
+		souceLabel.Value(source),
+		statusLabel.Value(fmt.Sprintf("%t", success)),
+	).Record(float64(t1.Sub(t0).Seconds()))
+	pollingsCount.With(
+		souceLabel.Value(source),
+		statusLabel.Value(fmt.Sprintf("%t", success)),
+	).Increment()
+}
+
+// RecordServiceEntryCreation records the number of service entries created by source.
+func RecordServiceEntryCreation(source string, buildEvent bool) {
+	serviceEntryCreation.With(souceLabel.Value(source)).Increment()
+	serviceEntryTotal.With(souceLabel.Value(source)).Increment()
+	sourceEventCount.With(
+		souceLabel.Value(source),
+		configTypeLabel.Value(servceEntryType),
+		sourceEventTypeLabel.Value(event.Added.String()),
+		statusLabel.Value(fmt.Sprintf("%t", buildEvent)),
+	).Increment()
+}
+
+// RecordServiceEntryDeletion records the number of service entries deleted by source.
+func RecordServiceEntryDeletion(source string, delete, buildEvent bool) {
+	serviceEntryDeletion.With(souceLabel.Value(source)).Increment()
+	eventType := event.Updated
+	if delete {
+		// todo: decrement
+		// serviceEntryTotal.With(souceLabel.Value(source)).Decrement()
+		eventType = event.Deleted
+	}
+	sourceEventCount.With(
+		souceLabel.Value(source),
+		configTypeLabel.Value(servceEntryType),
+		sourceEventTypeLabel.Value(eventType.String()),
+		statusLabel.Value(fmt.Sprintf("%t", buildEvent)),
+	).Increment()
+}
+
+// RecordServiceEntryUpdate records the number of service entries updated by source.
+func RecordServiceEntryUpdate(source string, buildEvent bool) {
+	serviceEntryUpdate.With(souceLabel.Value(source)).Increment()
+	sourceEventCount.With(
+		souceLabel.Value(source),
+		configTypeLabel.Value(servceEntryType),
+		sourceEventTypeLabel.Value(event.Updated.String()),
+		statusLabel.Value(fmt.Sprintf("%t", buildEvent)),
+	).Increment()
+}
+
+// RecordSidecarCreation records the number of sidecars created by source.
+func RecordSidecarCreation(source string) {
+	sidecarCreation.With(souceLabel.Value(source)).Increment()
+	sidecarTotal.With(souceLabel.Value(source)).Increment()
+	sourceEventCount.With(
+		souceLabel.Value(source),
+		configTypeLabel.Value(sidecarType),
+		sourceEventTypeLabel.Value(event.Added.String()),
+		statusLabel.Value("true"),
+	).Increment()
+}
+
+// RecordSidecarDeletion records the number of sidecars deleted by source.
+func RecordSidecarDeletion(source string) {
+	sidecarDeletion.With(souceLabel.Value(source)).Increment()
+	sidecarTotal.With(souceLabel.Value(source)).Decrement()
+	sourceEventCount.With(
+		souceLabel.Value(source),
+		configTypeLabel.Value(sidecarType),
+		sourceEventTypeLabel.Value(event.Deleted.String()),
+		statusLabel.Value("true"),
+	).Increment()
+}
+
+// RecordSidecarUpdate records the number of sidecars updated by source.
+func RecordSidecarUpdate(source string) {
+	sidecarUpdate.With(souceLabel.Value(source)).Increment()
+	sourceEventCount.With(
+		souceLabel.Value(source),
+		configTypeLabel.Value(sidecarType),
+		sourceEventTypeLabel.Value(event.Updated.String()),
+		statusLabel.Value("true"),
+	).Increment()
+}
+
+// RecordSourceClientRequest records the number of client requests by source.
+func RecordSourceClientRequest(source string, success bool) {
+	sourceClientRequestCount.With(
+		souceLabel.Value(source),
+		statusLabel.Value(fmt.Sprintf("%t", success)),
+	).Increment()
+}

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/server/httpServer.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/server/httpServer.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/kube-openapi/pkg/common"
 
 	"slime.io/slime/modules/meshregistry/pkg/mcpoverxds"
+	"slime.io/slime/modules/meshregistry/pkg/monitoring"
 	"slime.io/slime/modules/meshregistry/pkg/util/cache"
 )
 
@@ -48,6 +49,7 @@ func (hs *HttpServer) start() {
 	}
 
 	go func() {
+		t0 := time.Now()
 		for {
 			if len(hs.unreadySources()) == 0 {
 				break
@@ -60,6 +62,9 @@ func (hs *HttpServer) start() {
 		hs.lock.Lock()
 		hs.sourceReady = true
 		hs.lock.Unlock()
+		// Since the polling check method is used, the time statistics of source ready are not accurate enough,
+		// which is only for reference, but marking source ready is part of meshregistry ready
+		monitoring.RecordReady("sources", t0, time.Now())
 
 		if cb := hs.sourceReadyCallback; cb != nil {
 			cb(hs.mcpController, hs.startWG)

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/server/processing.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/server/processing.go
@@ -38,6 +38,7 @@ import (
 	slimebootstrap "slime.io/slime/framework/bootstrap"
 	"slime.io/slime/modules/meshregistry/pkg/bootstrap"
 	"slime.io/slime/modules/meshregistry/pkg/mcpoverxds"
+	"slime.io/slime/modules/meshregistry/pkg/monitoring"
 	"slime.io/slime/modules/meshregistry/pkg/multicluster"
 	"slime.io/slime/modules/meshregistry/pkg/source/eureka"
 	"slime.io/slime/modules/meshregistry/pkg/source/k8s"
@@ -267,6 +268,7 @@ func (p *Processing) Start() (err error) {
 	p.httpServer.ListenerRegistry(mcpController, startWG, p.startXdsOverMcp)
 
 	go func() {
+		monitoring.RecordEnabledSource(len(csrc))
 		for _, src := range csrc {
 			src.Start()
 		}
@@ -333,12 +335,14 @@ func (p *Processing) getDeployKubeClient() (k kube.Interfaces, err error) {
 }
 
 func (p *Processing) createFileKubeSource(schemas collection.Schemas, filePath string, watchFiles bool) (
-	src event.Source, err error) {
+	src event.Source, err error,
+) {
 	return fsNew(filePath, schemas, watchFiles)
 }
 
 func (p *Processing) createKubeSource(schemas collection.Schemas) (
-	src event.Source, err error) {
+	src event.Source, err error,
+) {
 	o := apiserver.Options{
 		Client:            p.k,
 		WatchedNamespaces: p.regArgs.K8SSource.WatchedNamespaces,

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/eureka/client.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/eureka/client.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"slime.io/slime/modules/meshregistry/pkg/bootstrap"
+	"slime.io/slime/modules/meshregistry/pkg/monitoring"
 )
 
 type application struct {
@@ -127,6 +128,7 @@ func (c *client) Applications() ([]*application, error) {
 	req.Header.Set("Accept", "application/json")
 
 	resp, err := c.client.Do(req)
+	monitoring.RecordSourceClientRequest(SourceName, err == nil)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/eureka/source.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/eureka/source.go
@@ -17,6 +17,7 @@ import (
 	frameworkmodel "slime.io/slime/framework/model"
 	"slime.io/slime/modules/meshregistry/model"
 	"slime.io/slime/modules/meshregistry/pkg/bootstrap"
+	"slime.io/slime/modules/meshregistry/pkg/monitoring"
 	"slime.io/slime/modules/meshregistry/pkg/source"
 	"slime.io/slime/modules/meshregistry/pkg/util"
 )
@@ -137,12 +138,16 @@ func (s *Source) refresh() {
 		s.started = false
 	}()
 	s.started = true
-	log.Infof("eureka refresh start : %d", time.Now().UnixNano())
+	t0 := time.Now()
+	log.Infof("eureka refresh start : %d", t0.UnixNano())
 	if err := s.updateServiceInfo(); err != nil {
+		monitoring.RecordPolling(SourceName, t0, time.Now(), false)
 		log.Errorf("eureka update service info failed: %v", err)
 		return
 	}
-	log.Infof("eureka refresh finsh : %d", time.Now().UnixNano())
+	t1 := time.Now()
+	log.Infof("eureka refresh finsh : %d", t1.UnixNano())
+	monitoring.RecordPolling(SourceName, t0, t1, true)
 
 	s.markServiceEntryInitDone()
 }
@@ -168,7 +173,8 @@ func (s *Source) updateServiceInfo() error {
 			oldEntryCopy := *oldEntry
 			oldEntryCopy.Endpoints = make([]*networking.WorkloadEntry, 0)
 			newServiceEntryMap[service] = &oldEntryCopy
-			if event, err := buildEvent(event.Updated, &oldEntryCopy, service, s.args.ResourceNs); err == nil {
+			event, err := buildEvent(event.Updated, &oldEntryCopy, service, s.args.ResourceNs)
+			if err == nil {
 				log.Infof("delete(update) eureka se, hosts: %s ,ep: %s ,size : %d ", oldEntry.Hosts[0], printEps(oldEntry.Endpoints), len(oldEntry.Endpoints))
 				for _, h := range s.handlers {
 					h.Handle(event)
@@ -176,13 +182,15 @@ func (s *Source) updateServiceInfo() error {
 			} else {
 				log.Errorf("build delete event for %s failed: %v", service, err)
 			}
+			monitoring.RecordServiceEntryDeletion(SourceName, false, err == nil)
 		}
 	}
 
 	for service, newEntry := range newServiceEntryMap {
 		if oldEntry, ok := cache[service]; !ok {
 			// ADD
-			if event, err := buildEvent(event.Added, newEntry, service, s.args.ResourceNs); err == nil {
+			event, err := buildEvent(event.Added, newEntry, service, s.args.ResourceNs)
+			if err == nil {
 				log.Infof("add eureka se, hosts: %s ,ep: %s, size: %d ", newEntry.Hosts[0], printEps(newEntry.Endpoints), len(newEntry.Endpoints))
 				for _, h := range s.handlers {
 					h.Handle(event)
@@ -190,10 +198,12 @@ func (s *Source) updateServiceInfo() error {
 			} else {
 				log.Errorf("build add event for %s failed: %v", service, err)
 			}
+			monitoring.RecordServiceEntryCreation(SourceName, err == nil)
 		} else {
 			if !proto.Equal(oldEntry, newEntry) {
 				// UPDATE
-				if event, err := buildEvent(event.Updated, newEntry, service, s.args.ResourceNs); err == nil {
+				event, err := buildEvent(event.Updated, newEntry, service, s.args.ResourceNs)
+				if err == nil {
 					log.Infof("update eureka se, hosts: %s, ep: %s, size: %d ", newEntry.Hosts[0], printEps(newEntry.Endpoints), len(newEntry.Endpoints))
 					for _, h := range s.handlers {
 						h.Handle(event)
@@ -201,6 +211,7 @@ func (s *Source) updateServiceInfo() error {
 				} else {
 					log.Errorf("build update event for %s failed: %v", service, err)
 				}
+				monitoring.RecordServiceEntryUpdate(SourceName, err == nil)
 			}
 		}
 	}
@@ -260,8 +271,10 @@ func (s *Source) Dispatch(handler event.Handler) {
 
 func (s *Source) Start() {
 	if s.initedCallback != nil {
+		t0 := time.Now()
 		go func() {
 			s.initWg.Wait()
+			monitoring.RecordReady(SourceName, t0, time.Now())
 			s.initedCallback(SourceName)
 		}()
 	}

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/nacos/polling.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/nacos/polling.go
@@ -7,6 +7,8 @@ import (
 	"github.com/gogo/protobuf/proto"
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/libistio/pkg/config/event"
+
+	"slime.io/slime/modules/meshregistry/pkg/monitoring"
 )
 
 func (s *Source) Polling() {
@@ -33,12 +35,16 @@ func (s *Source) refresh() {
 		s.started = false
 	}()
 	s.started = true
-	log.Infof("nacos refresh start : %d", time.Now().UnixNano())
+	t0 := time.Now()
+	log.Infof("nacos refresh start : %d", t0.UnixNano())
 	if err := s.updateServiceInfo(); err != nil {
+		monitoring.RecordPolling(SourceName, t0, time.Now(), false)
 		log.Errorf("eureka update service info failed: %v", err)
 		return
 	}
-	log.Infof("nacos refresh finsh : %d", time.Now().UnixNano())
+	t1 := time.Now()
+	log.Infof("nacos refresh finsh : %d", t1.UnixNano())
+	monitoring.RecordPolling(SourceName, t0, t1, true)
 	s.markServiceEntryInitDone()
 }
 
@@ -46,7 +52,6 @@ func (s *Source) updateServiceInfo() error {
 	instances, err := s.client.Instances()
 	if err != nil {
 		return fmt.Errorf("get nacos instances failed: %v", err)
-
 	}
 
 	if s.reGroupInstances != nil {
@@ -68,7 +73,8 @@ func (s *Source) updateServiceInfo() error {
 			oldEntryCopy := *oldEntry
 			oldEntryCopy.Endpoints = make([]*networking.WorkloadEntry, 0)
 			newServiceEntryMap[service] = &oldEntryCopy
-			if event, err := buildEvent(event.Updated, oldEntry, service, s.args.ResourceNs, seMetaModifierFactory(service)); err == nil {
+			event, err := buildEvent(event.Updated, oldEntry, service, s.args.ResourceNs, seMetaModifierFactory(service))
+			if err == nil {
 				log.Infof("delete(update) nacos se, hosts: %s ,ep: %s ,size : %d ", oldEntry.Hosts[0], printEps(oldEntry.Endpoints), len(oldEntry.Endpoints))
 				for _, h := range s.handlers {
 					h.Handle(event)
@@ -76,13 +82,15 @@ func (s *Source) updateServiceInfo() error {
 			} else {
 				log.Errorf("build delete event for %s failed: %v", service, err)
 			}
+			monitoring.RecordServiceEntryDeletion(SourceName, false, err == nil)
 		}
 	}
 
 	for service, newEntry := range newServiceEntryMap {
 		if oldEntry, ok := cache[service]; !ok {
 			// ADD
-			if event, err := buildEvent(event.Added, newEntry, service, s.args.ResourceNs, seMetaModifierFactory(service)); err == nil {
+			event, err := buildEvent(event.Added, newEntry, service, s.args.ResourceNs, seMetaModifierFactory(service))
+			if err == nil {
 				log.Infof("add nacos se, hosts: %s ,ep: %s, size: %d ", newEntry.Hosts[0], printEps(newEntry.Endpoints), len(newEntry.Endpoints))
 				for _, h := range s.handlers {
 					h.Handle(event)
@@ -90,17 +98,20 @@ func (s *Source) updateServiceInfo() error {
 			} else {
 				log.Errorf("build add event for %s failed: %v", service, err)
 			}
+			monitoring.RecordServiceEntryCreation(SourceName, err == nil)
 		} else {
 			if !proto.Equal(oldEntry, newEntry) {
 				// UPDATE
-				if event, err := buildEvent(event.Updated, newEntry, service, s.args.ResourceNs, seMetaModifierFactory(service)); err == nil {
+				event, err := buildEvent(event.Updated, newEntry, service, s.args.ResourceNs, seMetaModifierFactory(service))
+				if err == nil {
 					log.Infof("update nacos se, hosts: %s, ep: %s, size: %d ", newEntry.Hosts[0], printEps(newEntry.Endpoints), len(newEntry.Endpoints))
 					for _, h := range s.handlers {
 						h.Handle(event)
 					}
+				} else {
+					log.Errorf("build update event for %s failed: %v", service, err)
 				}
-			} else {
-				log.Errorf("build update event for %s failed: %v", service, err)
+				monitoring.RecordServiceEntryUpdate(SourceName, err == nil)
 			}
 		}
 	}

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/source.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/source.go
@@ -1,11 +1,12 @@
 package source
 
 import (
+	"strings"
+	"time"
+
 	frameworkmodel "slime.io/slime/framework/model"
 	"slime.io/slime/modules/meshregistry/model"
 	"slime.io/slime/modules/meshregistry/pkg/features"
-	"strings"
-	"time"
 
 	resource2 "istio.io/istio-mcp/pkg/config/schema/resource"
 	"istio.io/libistio/pkg/config/resource"

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/zookeeper/sidecar.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/zookeeper/sidecar.go
@@ -14,6 +14,7 @@ import (
 	"istio.io/libistio/pkg/config/resource"
 	"istio.io/libistio/pkg/config/schema/collections"
 
+	"slime.io/slime/modules/meshregistry/pkg/monitoring"
 	"slime.io/slime/modules/meshregistry/pkg/source"
 )
 
@@ -183,9 +184,11 @@ func (s *Source) refreshSidecar(init bool) {
 		prev, ok := prevSidecarCache[fn]
 		if !ok {
 			events = append(events, buildSidecarEvent(event.Added, cur.Sidecar, cur.Meta))
+			monitoring.RecordSidecarCreation(SourceName)
 			added++
 		} else if !prev.Equals(cur) {
 			events = append(events, buildSidecarEvent(event.Updated, cur.Sidecar, cur.Meta))
+			monitoring.RecordSidecarUpdate(SourceName)
 			updated++
 		}
 	}
@@ -194,6 +197,7 @@ func (s *Source) refreshSidecar(init bool) {
 		for fn, prev := range prevSidecarCache {
 			if _, ok := sidecarMap[fn]; !ok {
 				events = append(events, buildSidecarEvent(event.Deleted, prev.Sidecar, prev.Meta))
+				monitoring.RecordSidecarDeletion(SourceName)
 				deleted++
 			}
 		}
@@ -392,7 +396,6 @@ func convertDubboCallModel(se *networking.ServiceEntry, inboundEndpoints []*netw
 
 			m[interfaceName] = struct{}{}
 		}
-
 	}
 
 	return dubboModels


### PR DESCRIPTION
添加 meshreg 指标：
- slime_meshregistry_enabled_source： 当前启用的注册中心总数
- slime_meshregistry_mcp_push_count：当前实例向 istiod 推送的次数
- slime_meshregistry_ready_time：启用的注册中心 source 达到就绪状态的耗时
- slime_meshregistry_polling_time：轮训模式从注册中心完成一次全量服务数据同步的耗时分布，分注册中心
- slime_meshregistry_polling_count：轮训模式向注册中心执行的全量服务数据同步的次数，分注册中心
- slime_meshregistry_service_entry_{creation,deletion,update}：执行 se 创建、删除、更新的次数，分注册中心
- slime_meshregistry_service_entry_total：当前内存中保存的 se 的总数
- slime_meshregistry_sidecar_{creation,deletion,update}：执行 sidecar 创建、删除、更新的次数，分注册中心
- slime_meshregistry_sidecar_total：当前内存中保存的 sidecar 的总数
- slime_meshregistry_source_event_count：注册中心 source 产生的配置变更事件的次数，分注册中心、配置类型、事件类型
- slime_meshregistry_source_client_request_count：向注册中心发起的请求的次数，分注册中心