### PR TITLE
plugin: applyInlinePlugin supports non-empty typeURL and nil settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,7 @@ Session.vim
 tags
 ### VisualStudioCode ###
 .vscode/*
+*.code-workspace
 .history
 *.code-workspace
 ### idea ###
@@ -84,6 +85,9 @@ staging/src/slime.io/slime/modules/*/.idea/*
 .kube/*
 /build
 .qz/*
+
+### project ###
+/efficiency.json
 
 ### module helm chats ###
 boot/helm-charts/slimeboot/templates/modules/*

--- a/staging/src/slime.io/slime/modules/plugin/controllers/conversion.go
+++ b/staging/src/slime.io/slime/modules/plugin/controllers/conversion.go
@@ -731,6 +731,10 @@ func (r *PluginManagerReconciler) applyInlinePlugin(name, typeURL string, settin
 		},
 	}
 
+	if settings == nil && typeURL != "" {
+		settings = &v1alpha1.Plugin_Inline{Inline: &v1alpha1.Inline{}}
+	}
+
 	if settings != nil {
 		out.Fields[util.StructHttpFilterTypedConfig] = &types.Value{
 			Kind: &types.Value_StructValue{


### PR DESCRIPTION
对于一个plm插件:

```yaml
  - enable: true
     listenerType: Gateway
     name: envoy.filters.http.cors.v3
     port: 8080
     typeUrl: type.googleapis.com/envoy.extensions.filters.http.cors.v3.Cors
```

之前： typeUrl不生效，因为typeUrl对于有效config才有意义所以原代码中要求`inline`不为空才能正确生成，也即上述内容需要加上
```yaml
    inline: {}
```
才能正常工作。

之后： 对于该特殊场景（指定了typeUrl又并无实际内容需要设置），（不设置`inline: {}`就）可以正确生成对应配置

```yaml
      operation: INSERT_BEFORE
      value:
        name: envoy.filters.http.cors.v3
        typed_config:
          '@type': type.googleapis.com/udpa.type.v1.TypedStruct
          type_url: type.googleapis.com/envoy.extensions.filters.http.cors.v3.Cors
          value: {}
```


