### PR TITLE
meshreg: fix typo of zk source default consumer node

### DIFF
--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/zookeeper/source.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/zookeeper/source.go
@@ -55,7 +55,7 @@ const (
 
 const (
 	providerPathSuffix  = "/" + ProviderNode
-	consumerPathSuffix  = "/" + ConfiguratorNode
+	consumerPathSuffix  = "/" + ConsumerNode
 	disableConsumerPath = "-"
 	configuratorSuffix  = "/" + ConfiguratorNode
 )


### PR DESCRIPTION
import from: https://github.com/slime-io/slime/pull/489. Causes dependencies to be unavailable using historical configurations.