### PR TITLE
meshreg: zk source support empty value protection

### DIFF
--- a/framework/util/set.go
+++ b/framework/util/set.go
@@ -1,0 +1,24 @@
+package util
+
+type Set[V comparable] map[V]struct{}
+
+func NewSet[V comparable]() Set[V] {
+	return make(Set[V])
+}
+
+func (s Set[V]) Insert(v V) {
+	s[v] = struct{}{}
+}
+
+func (s Set[V]) Remove(v V) {
+	delete(s, v)
+}
+
+func (s Set[V]) Contains(v V) bool {
+	_, ok := s[v]
+	return ok
+}
+
+func (s Set[V]) Len() int {
+	return len(s)
+}

--- a/go.work
+++ b/go.work
@@ -13,8 +13,8 @@ use (
 
 replace (
 	// slime lib
-	istio.io/istio-mcp => github.com/slime-io/istio-mcp v0.0.0-20240116022210-c7970f94037d
-	istio.io/libistio => github.com/slime-io/libistio v0.0.0-20240104031034-b2f5e0749ccc
+	istio.io/istio-mcp => github.com/slime-io/istio-mcp v0.0.0-20240319031437-de3690e6f139
+	istio.io/libistio => github.com/slime-io/libistio v0.0.0-20240319025542-9b29030c6429
 	github.com/go-zookeeper/zk => github.com/slime-io/go-zk v0.0.0-20231205121800-d3e53bc03897
 	slime.io/pkg => github.com/slime-io/pkg v0.0.0-20230517042057-3fbf1159a7a7
 

--- a/go.work.sum
+++ b/go.work.sum
@@ -800,8 +800,6 @@ github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbV
 github.com/go-logr/logr v1.2.3/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.2.4 h1:g01GSCwiDw2xSZfjJ2/T9M+S6pFdcNtFYsp+Y43HYDQ=
 github.com/go-logr/logr v1.2.4/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
-github.com/go-logr/logr v1.4.1 h1:pKouT5E8xu9zeFC39JXRDukb6JFQPXM5p5I91188VAQ=
-github.com/go-logr/logr v1.4.1/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/zapr v1.2.3/go.mod h1:eIauM6P8qSvTw5o2ez6UEAfGjQKrxQTl5EoK+Qa2oG4=
 github.com/go-openapi/jsonreference v0.20.0/go.mod h1:Ag74Ico3lPc+zR+qjn4XBUmXymS4zJbYVCZmcgkasdo=
 github.com/go-openapi/jsonreference v0.20.1/go.mod h1:Bl1zwGIM8/wsvqjsOQLJ/SH+En5Ap4rVB5KVcIDZG2k=
@@ -1010,6 +1008,10 @@ github.com/ruudk/golang-pdf417 v0.0.0-20181029194003-1af4ab5afa58/go.mod h1:6lfF
 github.com/ruudk/golang-pdf417 v0.0.0-20201230142125-a7e3863a1245/go.mod h1:pQAZKsJ8yyVxGRWYNEm9oFB8ieLgKFnamEyDmSA0BRk=
 github.com/slime-io/go-zk v0.0.0-20231205121800-d3e53bc03897 h1:Mb/hedX3IXmVkYMIQaEYptLg17BDGuu3Pzv/XpLaNYo=
 github.com/slime-io/go-zk v0.0.0-20231205121800-d3e53bc03897/go.mod h1:nOB03cncLtlp4t+UAkGSV+9beXP/akpekBwL+UX1Qcw=
+github.com/slime-io/istio-mcp v0.0.0-20240319031437-de3690e6f139 h1:J3yHvdFIRFYlY5MzmS5jlefBZquFOZlKs2hrwc9gAMk=
+github.com/slime-io/istio-mcp v0.0.0-20240319031437-de3690e6f139/go.mod h1:/JvkgYSFxzIzE9dVq8LDsiUDj7Izr3aGTrJW2ZG9rso=
+github.com/slime-io/libistio v0.0.0-20240319025542-9b29030c6429 h1:99fHy1T1ElayPgGd9IBuqIbhl8+lhfZWSpcPFE9prR4=
+github.com/slime-io/libistio v0.0.0-20240319025542-9b29030c6429/go.mod h1:3KhSVR3uXVIcSqVvPCc/5U+QgAsBM32HJ+xKpDQRmDs=
 github.com/soheilhy/cmux v0.1.5/go.mod h1:T7TcVDs9LWfQgPlPsdngu6I6QIoyIFZDDC6sNE1GqG0=
 github.com/spf13/afero v1.3.3/go.mod h1:5KUK8ByomD5Ti5Artl0RtHeI5pTF7MIDuXL3yY520V4=
 github.com/spf13/afero v1.6.0/go.mod h1:Ai8FlHk4v/PARR026UzYexafAt9roJ7LcLMAmO6Z93I=
@@ -1067,8 +1069,6 @@ go.opentelemetry.io/otel v1.10.0 h1:Y7DTJMR6zs1xkS/upamJYk0SxxN4C9AqRd77jmZnyY4=
 go.opentelemetry.io/otel v1.10.0/go.mod h1:NbvWjCthWHKBEUMpf0/v8ZRZlni86PpGFEMA9pnQSnQ=
 go.opentelemetry.io/otel v1.14.0/go.mod h1:o4buv+dJzx8rohcUeRmWUZhqupFvzWis188WlggnNeU=
 go.opentelemetry.io/otel v1.16.0/go.mod h1:vl0h9NUa1D5s1nv3A5vZOYWn8av4K8Ml6JDeHrT/bx4=
-go.opentelemetry.io/otel v1.23.0 h1:Df0pqjqExIywbMCMTxkAwzjLZtRf+bBKLbUcpxO2C9E=
-go.opentelemetry.io/otel v1.23.0/go.mod h1:YCycw9ZeKhcJFrb34iVSkyT0iczq/zYDtZYFufObyB0=
 go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.10.0/go.mod h1:78XhIg8Ht9vR4tbLNUhXsiOnE2HOuSeKAiAcoVQEpOY=
 go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.16.0/go.mod h1:vLarbg68dH2Wa77g71zmKQqlQ8+8Rq3GRG31uc0WcWI=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.0.1/go.mod h1:Kv8liBeVNFkkkbilbgWRpV+wWuu+H5xdOT6HAgd30iw=
@@ -1080,8 +1080,6 @@ go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.16.0/go.mod h
 go.opentelemetry.io/otel/metric v0.31.0 h1:6SiklT+gfWAwWUR0meEMxQBtihpiEs4c+vL9spDTqUs=
 go.opentelemetry.io/otel/metric v0.31.0/go.mod h1:ohmwj9KTSIeBnDBm/ZwH2PSZxZzoOaG2xZeekTRzL5A=
 go.opentelemetry.io/otel/metric v1.16.0/go.mod h1:QE47cpOmkwipPiefDwo2wDzwJrlfxxNYodqc4xnGCo4=
-go.opentelemetry.io/otel/metric v1.23.0 h1:pazkx7ss4LFVVYSxYew7L5I6qvLXHA0Ap2pwV+9Cnpo=
-go.opentelemetry.io/otel/metric v1.23.0/go.mod h1:MqUW2X2a6Q8RN96E2/nqNoT+z9BSms20Jb7Bbp+HiTo=
 go.opentelemetry.io/otel/sdk v1.0.1/go.mod h1:HrdXne+BiwsOHYYkBE5ysIcv2bvdZstxzmCQhxTcZkI=
 go.opentelemetry.io/otel/sdk v1.10.0 h1:jZ6K7sVn04kk/3DNUdJ4mqRlGDiXAVuIG+MMENpTNdY=
 go.opentelemetry.io/otel/sdk v1.10.0/go.mod h1:vO06iKzD5baltJz1zarxMCNHFpUlUiOy4s65ECtn6kE=
@@ -1091,8 +1089,6 @@ go.opentelemetry.io/otel/trace v1.10.0 h1:npQMbR8o7mum8uF95yFbOEJffhs1sbCOfDh8zA
 go.opentelemetry.io/otel/trace v1.10.0/go.mod h1:Sij3YYczqAdz+EhmGhE6TpTxUO5/F/AzrK+kxfGqySM=
 go.opentelemetry.io/otel/trace v1.14.0/go.mod h1:8avnQLK+CG77yNLUae4ea2JDQ6iT+gozhnZjy/rw9G8=
 go.opentelemetry.io/otel/trace v1.16.0/go.mod h1:Yt9vYq1SdNz3xdjZZK7wcXv1qv2pwLkqr2QVwea0ef0=
-go.opentelemetry.io/otel/trace v1.23.0 h1:37Ik5Ib7xfYVb4V1UtnT97T1jI+AoIYkJyPkuL4iJgI=
-go.opentelemetry.io/otel/trace v1.23.0/go.mod h1:GSGTbIClEsuZrGIzoEHqsVfxgn5UkggkflQwDScNUsk=
 go.opentelemetry.io/proto/otlp v0.9.0/go.mod h1:1vKfU9rv61e9EVGthD1zNvUbiwPcimSsOPU9brfSHJg=
 go.opentelemetry.io/proto/otlp v0.19.0 h1:IVN6GR+mhC4s5yfcTbmzHYODqvWAp3ZedA2SJPI1Nnw=
 go.opentelemetry.io/proto/otlp v0.19.0/go.mod h1:H7XAot3MsfNsj7EXtrA2q5xSNQ10UqI405h3+duxN4U=

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/bootstrap/args.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/bootstrap/args.go
@@ -147,6 +147,10 @@ type SourceArgs struct {
 	// InstanceMetaRelabel is used to adjust the metadata of the instance.
 	// Note that ServiceNaming may refer to instance metadata, the InstanceMetaRelabel needs to be processed before ServiceNaming
 	InstanceMetaRelabel *InstanceMetaRelabel `json:"InstanceMetaRelabel,omitempty"`
+
+	// EnableEmptyProtection if set to true, the source should ignore conversion of the service with no endpoints, which means
+	// the last conversion result with endpoints will be kept until the source gets the new endpoints.
+	EnableEmptyProtection bool `json:"EnableEmptyProtection,omitempty"`
 }
 
 // IPRanges defines a set of ip with ip list and cidr list


### PR DESCRIPTION
支持对 zk(dubbo) 服务的推空保护，该功能开启后会忽略掉广义上的服务下线事件：

- 实例清空。当 `providers` 目录下实例出现从 `n` 到 `0` 的变化时，zk 不会处理该变化，对应 interface 转换出的 se 将保持不变，直到下一次的有实例上线。
- Interface 下线。当对应 interface 目录在 zk 中被删除时，对应 interface 转换出的 se 将保持不变，直到下一次该 interface 被重新注册，且存在可用实例。

该功能仅适用于特定的场景，确认开启前请根据具体环境信息评估风险。

使用说明：
``` yaml
ZookeeperSource:
  EnableEmptyProtection: true
```