### PR TITLE
meshreg: enhance InstanceMetaRelabel to support adding new KV and add zk support for it

### DIFF
--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/bootstrap/args.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/bootstrap/args.go
@@ -243,6 +243,9 @@ type InstanceMetaRelabelItem struct {
 	TargetKey string `json:"TargetKey,omitempty"`
 	// Whether to overwrite the value of the TargetKey if it already exists in the instance metadata.
 	Overwrite bool `json:"Overwrite,omitempty"`
+	// If the CreatedWithValue is not empty and the Key is not found in the instance metadata,
+	// the TargetKey will be set to the CreatedWithValue value.
+	CreatedWithValue string `json:"CreatedWithDeafult,omitempty"`
 	// ValuesMapping is a map that associates values of the Key to values of the TargetKey.
 	// If the Key's value is found in the map, the corresponding value is used for the TargetKey.
 	// If not, the original value is used for the TargetKey.

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/source_test.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/source_test.go
@@ -1,0 +1,130 @@
+package source
+
+import (
+	"reflect"
+	"testing"
+
+	"slime.io/slime/modules/meshregistry/pkg/bootstrap"
+)
+
+func TestBuildInstanceMetaModifier(t *testing.T) {
+	type args struct {
+		rl *bootstrap.InstanceMetaRelabel
+	}
+	tests := []struct {
+		name     string
+		args     args
+		meta     map[string]string
+		wantMeta map[string]string
+	}{
+		{
+			name: "relabel with mapping value",
+			args: args{
+				rl: &bootstrap.InstanceMetaRelabel{
+					Items: []*bootstrap.InstanceMetaRelabelItem{
+						{
+							Key:       "foo",
+							TargetKey: "foo1",
+							ValuesMapping: map[string]string{
+								"bar": "baz",
+							},
+						},
+					},
+				},
+			},
+			meta: map[string]string{
+				"foo": "bar",
+			},
+			wantMeta: map[string]string{
+				"foo":  "bar",
+				"foo1": "baz",
+			},
+		},
+		{
+			name: "relabel without overwrite",
+			args: args{
+				rl: &bootstrap.InstanceMetaRelabel{
+					Items: []*bootstrap.InstanceMetaRelabelItem{
+						{
+							Key:       "foo",
+							TargetKey: "foo1",
+						},
+					},
+				},
+			},
+			meta: map[string]string{
+				"foo":  "bar",
+				"foo1": "bar1",
+			},
+			wantMeta: map[string]string{
+				"foo":  "bar",
+				"foo1": "bar1",
+			},
+		},
+		{
+			name: "relabel with overwrite",
+			args: args{
+				rl: &bootstrap.InstanceMetaRelabel{
+					Items: []*bootstrap.InstanceMetaRelabelItem{
+						{
+							Key:       "foo",
+							TargetKey: "foo1",
+							Overwrite: true,
+						},
+					},
+				},
+			},
+			meta: map[string]string{
+				"foo":  "bar",
+				"foo1": "bar1",
+			},
+			wantMeta: map[string]string{
+				"foo":  "bar",
+				"foo1": "bar",
+			},
+		},
+		{
+			name: "create new label with nil map",
+			args: args{
+				rl: &bootstrap.InstanceMetaRelabel{
+					Items: []*bootstrap.InstanceMetaRelabelItem{
+						{
+							Key:              "foo",
+							TargetKey:        "foo",
+							CreatedWithValue: "bar",
+						},
+					},
+				},
+			},
+			wantMeta: map[string]string{
+				"foo": "bar",
+			},
+		},
+		{
+			name: "create new label with empty map",
+			args: args{
+				rl: &bootstrap.InstanceMetaRelabel{
+					Items: []*bootstrap.InstanceMetaRelabelItem{
+						{
+							Key:              "foo",
+							TargetKey:        "foo",
+							CreatedWithValue: "bar",
+						},
+					},
+				},
+			},
+			meta: map[string]string{},
+			wantMeta: map[string]string{
+				"foo": "bar",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := BuildInstanceMetaModifier(tt.args.rl)
+			if got(&tt.meta); !reflect.DeepEqual(tt.meta, tt.wantMeta) {
+				t.Errorf("after do modifiy = %v, want %v", tt.meta, tt.wantMeta)
+			}
+		})
+	}
+}

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/zookeeper/conversion.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/zookeeper/conversion.go
@@ -185,6 +185,9 @@ func (s *Source) convertServiceEntry(
 		if !ok {
 			continue
 		}
+		if s.instanceMetaModifier != nil {
+			s.instanceMetaModifier(&meta)
+		}
 		serviceKey := buildServiceKey(service, meta) // istio service host
 
 		// now we have the necessary info to build the dubboinstance,


### PR DESCRIPTION
This PR introduces the `CreatedWithValue` in the `InstanceMetaRelabel` API, enabling the addition of extra metadata pairs for instances. Additionally, it implements support for the `InstanceMetaRelabel` API on the zk source.

for example：

``` yaml
# zk config
ZookeeperSource:
  InstanceMetaRelabel:
    Items:
    - Key: foo
      TargetKey: foo
      CreatedWithValue: "bar"

# origional meta of the instance
hello: world

# new meta of the instance
hello: world
foo: bar
```