### PR TITLE
[TEST] add test for meshregistry source package

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -1054,6 +1054,7 @@ github.com/spf13/cobra v1.6.0/go.mod h1:IOw/AERYS7UzyrGinqmz6HLUo219MORXGxhbaJUq
 github.com/spf13/cobra v1.6.1/go.mod h1:IOw/AERYS7UzyrGinqmz6HLUo219MORXGxhbaJUqzrY=
 github.com/spf13/jwalterweatherman v1.1.0/go.mod h1:aNWZUN0dPAAO/Ljvb5BEdw96iTZ0EXowPYD95IqWIGo=
 github.com/spf13/viper v1.8.1/go.mod h1:o0Pch8wJ9BVSWGQMbra6iw0oQ5oktSIBaujf1rJH9Ns=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.3/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
@@ -1629,6 +1630,7 @@ gopkg.in/yaml.v3 v3.0.0/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools/v3 v3.4.0/go.mod h1:CtbdzLSsqVhDgMtKsx03ird5YTGB3ar27v0u/yKBW5g=
 helm.sh/helm/v3 v3.12.2/go.mod h1:v1PMayudIfZAvec3Wp4wAErensvK/rv5fu/xCiE6t3I=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
+honnef.co/go/tools v0.1.3 h1:qTakTkI6ni6LFD5sBwwsdSO+AQqbSIxOauHTTQKZ/7o=
 honnef.co/go/tools v0.1.3/go.mod h1:NgwopIslSNH47DimFoV78dnkksY2EFtX0ajyb3K/las=
 k8s.io/api v0.26.0 h1:IpPlZnxBpV1xl7TGk/X6lFtpgjgntCg8PJ+qrPHAC7I=
 k8s.io/api v0.26.0/go.mod h1:k6HDTaIFC8yn1i6pSClSqIwLABIcLV9l5Q4EcngKnQg=

--- a/staging/src/slime.io/slime/modules/bundle-all/go.mod
+++ b/staging/src/slime.io/slime/modules/bundle-all/go.mod
@@ -71,6 +71,7 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/orcaman/concurrent-map/v2 v2.0.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.17.0 // indirect
 	github.com/prometheus/client_model v0.5.0 // indirect
 	github.com/prometheus/common v0.45.0 // indirect
@@ -82,6 +83,7 @@ require (
 	github.com/spf13/cobra v1.7.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stoewer/go-strcase v1.3.0 // indirect
+	github.com/stretchr/testify v1.9.0 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect

--- a/staging/src/slime.io/slime/modules/bundle-all/go.sum
+++ b/staging/src/slime.io/slime/modules/bundle-all/go.sum
@@ -746,8 +746,9 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/staging/src/slime.io/slime/modules/bundle-hango/go.mod
+++ b/staging/src/slime.io/slime/modules/bundle-hango/go.mod
@@ -62,6 +62,7 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/orcaman/concurrent-map/v2 v2.0.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.17.0 // indirect
 	github.com/prometheus/client_model v0.5.0 // indirect
 	github.com/prometheus/common v0.45.0 // indirect
@@ -71,6 +72,7 @@ require (
 	github.com/spf13/cobra v1.7.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stoewer/go-strcase v1.3.0 // indirect
+	github.com/stretchr/testify v1.9.0 // indirect
 	go.opentelemetry.io/otel v1.23.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.39.1-0.20230714155235-03b8c47770f2 // indirect
 	go.opentelemetry.io/otel/metric v1.23.0 // indirect

--- a/staging/src/slime.io/slime/modules/bundle-hango/go.sum
+++ b/staging/src/slime.io/slime/modules/bundle-hango/go.sum
@@ -186,8 +186,9 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=

--- a/staging/src/slime.io/slime/modules/meshregistry/go.mod
+++ b/staging/src/slime.io/slime/modules/meshregistry/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/mitchellh/copystructure v1.2.0
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/sirupsen/logrus v1.9.0
+	github.com/stretchr/testify v1.9.0
 	google.golang.org/grpc v1.58.3
 	gopkg.in/yaml.v2 v2.4.0
 	istio.io/api v1.19.1
@@ -27,22 +28,61 @@ require (
 
 require (
 	github.com/antlr4-go/antlr/v4 v4.13.0 // indirect
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
 	github.com/census-instrumentation/opencensus-proto v0.4.1 // indirect
+	github.com/cespare/xxhash/v2 v2.2.0 // indirect
+	github.com/cncf/udpa/go v0.0.0-20220112060539-c52dc94e7fbe // indirect
+	github.com/cncf/xds/go v0.0.0-20230607035331-e9ce68804cb4 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0 // indirect
+	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
+	github.com/envoyproxy/go-control-plane v0.11.2-0.20230725211550-11bfe846bcd4 // indirect
+	github.com/envoyproxy/protoc-gen-validate v1.0.2 // indirect
+	github.com/evanphx/json-patch/v5 v5.7.0 // indirect
+	github.com/fsnotify/fsnotify v1.7.0 // indirect
+	github.com/ghodss/yaml v1.0.0 // indirect
+	github.com/go-logr/logr v1.4.1 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/go-openapi/jsonpointer v0.20.0 // indirect
+	github.com/go-openapi/jsonreference v0.20.2 // indirect
+	github.com/go-openapi/swag v0.22.4 // indirect
 	github.com/goccy/go-json v0.10.2 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/cel-go v0.18.2 // indirect
 	github.com/google/gnostic-models v0.6.8 // indirect
+	github.com/google/go-cmp v0.6.0 // indirect
+	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/pprof v0.0.0-20230602150820-91b7bce49751 // indirect
+	github.com/google/uuid v1.3.1 // indirect
+	github.com/hashicorp/errwrap v1.1.0 // indirect
+	github.com/imdario/mergo v1.0.0 // indirect
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/josharian/intern v1.0.0 // indirect
+	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/lestrrat-go/backoff/v2 v2.0.8 // indirect
 	github.com/lestrrat-go/blackmagic v1.0.2 // indirect
 	github.com/lestrrat-go/httpcc v1.0.1 // indirect
 	github.com/lestrrat-go/iter v1.0.2 // indirect
 	github.com/lestrrat-go/jwx v1.2.27 // indirect
 	github.com/lestrrat-go/option v1.0.1 // indirect
+	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0 // indirect
+	github.com/mitchellh/reflectwalk v1.0.2 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/orcaman/concurrent-map/v2 v2.0.1
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/prometheus/client_golang v1.17.0 // indirect
+	github.com/prometheus/client_model v0.5.0 // indirect
+	github.com/prometheus/common v0.45.0 // indirect
+	github.com/prometheus/procfs v0.12.0 // indirect
+	github.com/spf13/cobra v1.7.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stoewer/go-strcase v1.3.0 // indirect
 	go.opentelemetry.io/otel v1.23.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.39.1-0.20230714155235-03b8c47770f2 // indirect
@@ -51,54 +91,10 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v0.39.0 // indirect
 	go.opentelemetry.io/otel/trace v1.23.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.0.0 // indirect
-	golang.org/x/crypto v0.17.0 // indirect
-	golang.org/x/exp v0.0.0-20231006140011-7918f672742d // indirect
-	google.golang.org/genproto/googleapis/api v0.0.0-20230920204549-e6e6cdab5c13 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20231009173412-8bfb1ae86b6c // indirect
-	sigs.k8s.io/gateway-api v1.0.0 // indirect
-)
-
-require (
-	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
-	github.com/cespare/xxhash/v2 v2.2.0 // indirect
-	github.com/cncf/udpa/go v0.0.0-20220112060539-c52dc94e7fbe // indirect
-	github.com/cncf/xds/go v0.0.0-20230607035331-e9ce68804cb4 // indirect
-	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
-	github.com/envoyproxy/go-control-plane v0.11.2-0.20230725211550-11bfe846bcd4 // indirect
-	github.com/envoyproxy/protoc-gen-validate v1.0.2 // indirect
-	github.com/evanphx/json-patch/v5 v5.7.0 // indirect
-	github.com/fsnotify/fsnotify v1.7.0 // indirect
-	github.com/ghodss/yaml v1.0.0 // indirect
-	github.com/go-logr/logr v1.4.1 // indirect
-	github.com/go-openapi/jsonpointer v0.20.0 // indirect
-	github.com/go-openapi/jsonreference v0.20.2 // indirect
-	github.com/go-openapi/swag v0.22.4 // indirect
-	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
-	github.com/google/go-cmp v0.6.0 // indirect
-	github.com/google/gofuzz v1.2.0 // indirect
-	github.com/google/uuid v1.3.1 // indirect
-	github.com/hashicorp/errwrap v1.1.0 // indirect
-	github.com/imdario/mergo v1.0.0 // indirect
-	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/josharian/intern v1.0.0 // indirect
-	github.com/json-iterator/go v1.1.12 // indirect
-	github.com/mailru/easyjson v0.7.7 // indirect
-	github.com/mitchellh/reflectwalk v1.0.2 // indirect
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.2 // indirect
-	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/orcaman/concurrent-map/v2 v2.0.1
-	github.com/pkg/errors v0.9.1 // indirect
-	github.com/prometheus/client_golang v1.17.0 // indirect
-	github.com/prometheus/client_model v0.5.0 // indirect
-	github.com/prometheus/common v0.45.0 // indirect
-	github.com/prometheus/procfs v0.12.0 // indirect
-	github.com/spf13/cobra v1.7.0 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.26.0 // indirect
+	golang.org/x/crypto v0.17.0 // indirect
+	golang.org/x/exp v0.0.0-20231006140011-7918f672742d // indirect
 	golang.org/x/net v0.17.0 // indirect
 	golang.org/x/oauth2 v0.13.0 // indirect
 	golang.org/x/sys v0.15.0 // indirect
@@ -108,6 +104,8 @@ require (
 	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
 	google.golang.org/appengine v1.6.8 // indirect
 	google.golang.org/genproto v0.0.0-20231002182017-d307bd883b97 // indirect
+	google.golang.org/genproto/googleapis/api v0.0.0-20230920204549-e6e6cdab5c13 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20231009173412-8bfb1ae86b6c // indirect
 	google.golang.org/protobuf v1.31.0
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
@@ -117,6 +115,7 @@ require (
 	k8s.io/klog v1.0.0 // indirect
 	k8s.io/klog/v2 v2.110.1 // indirect
 	k8s.io/utils v0.0.0-20230726121419-3b25d923346b // indirect
+	sigs.k8s.io/gateway-api v1.0.0 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 )

--- a/staging/src/slime.io/slime/modules/meshregistry/go.sum
+++ b/staging/src/slime.io/slime/modules/meshregistry/go.sum
@@ -185,8 +185,9 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/eureka/mock_client.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/eureka/mock_client.go
@@ -1,0 +1,17 @@
+package eureka
+
+import "slime.io/slime/modules/meshregistry/pkg/source/sourcetest"
+
+var _ Client = (*MockClient)(nil)
+
+type MockClient struct {
+	sourcetest.MockPollingClient[application]
+}
+
+func (m *MockClient) Applications() ([]*application, error) {
+	return m.Services()
+}
+
+func (m *MockClient) RegistryInfo() string {
+	return m.MockPollingClient.RegistryInfo()
+}

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/eureka/source_test.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/eureka/source_test.go
@@ -112,6 +112,9 @@ func TestUpdateServiceInfo(t *testing.T) {
 				},
 			},
 		},
+		// TODO: add test cases for:
+		// - mock merged ServiceEntry
+		// - ...
 	}
 
 	initTest := func(s *Source) {

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/eureka/source_test.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/eureka/source_test.go
@@ -1,0 +1,145 @@
+package eureka
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"slime.io/slime/modules/meshregistry/pkg/bootstrap"
+	"slime.io/slime/modules/meshregistry/pkg/source/sourcetest"
+)
+
+func TestUpdateServiceInfo(t *testing.T) {
+	type testData struct {
+		// clientErr is the error returned by the mock client
+		clientErr error
+		// in is the json format input file path
+		in string
+		// expect is the yaml format expected file path
+		expect string
+	}
+	assertHandler := sourcetest.NewAssertEventHandler()
+	mockClient := &MockClient{}
+	args := []struct {
+		name           string
+		data           []testData
+		s              *Source
+		enableFeatures func()
+	}{
+		{
+			name: "simple",
+			data: []testData{
+				{
+					in:     "./testdata/simple.json",
+					expect: "./testdata/simple.expected.yaml",
+				},
+			},
+			s: &Source{
+				args: &bootstrap.EurekaSourceArgs{
+					SourceArgs: bootstrap.SourceArgs{
+						SvcProtocol:           "http",
+						InstancePortAsSvcPort: true,
+						ResourceNs:            "eureka",
+						DefaultServiceNs:      "eureka",
+					},
+				},
+			},
+		},
+		{
+			name: "simple-scale-down-instance",
+			data: []testData{
+				{
+					in:     "./testdata/simple.json",
+					expect: "./testdata/simple.expected.yaml",
+				},
+				{
+					in:     "./testdata/simple_scale_down_instance.json",
+					expect: "./testdata/simple_scale_down_instance.expected.yaml",
+				},
+			},
+			s: &Source{
+				args: &bootstrap.EurekaSourceArgs{
+					SourceArgs: bootstrap.SourceArgs{
+						SvcProtocol:           "http",
+						InstancePortAsSvcPort: true,
+						ResourceNs:            "eureka",
+						DefaultServiceNs:      "eureka",
+					},
+				},
+			},
+		},
+		{
+			name: "legacy_gateway_mode",
+			data: []testData{
+				{
+					in:     "./testdata/legacy_gateway_mode.json",
+					expect: "./testdata/legacy_gateway_mode.expected.yaml",
+				},
+			},
+			s: &Source{
+				args: &bootstrap.EurekaSourceArgs{
+					SourceArgs: bootstrap.SourceArgs{
+						SvcProtocol:           "http",
+						SvcPort:               80,
+						InstancePortAsSvcPort: false,
+						ResourceNs:            "eureka",
+						DefaultServiceNs:      "eureka",
+					},
+					NsHost: true,
+				},
+			},
+		},
+		{
+			name: "enable-project-code",
+			data: []testData{
+				{
+					in:     "./testdata/project_code.json",
+					expect: "./testdata/project_code.expected.yaml",
+				},
+			},
+			s: &Source{
+				args: &bootstrap.EurekaSourceArgs{
+					SourceArgs: bootstrap.SourceArgs{
+						SvcProtocol:           "http",
+						SvcPort:               80,
+						InstancePortAsSvcPort: false,
+						ResourceNs:            "eureka",
+						DefaultServiceNs:      "eureka",
+					},
+					NsHost:            true,
+					EnableProjectCode: true,
+					AppSuffix:         "nsf",
+				},
+			},
+		},
+	}
+
+	initTest := func(s *Source) {
+		mockClient.Reset()
+		s.client = mockClient
+		assertHandler.Reset()
+		s.Dispatch(assertHandler)
+	}
+
+	for _, tt := range args {
+		initTest(tt.s)
+		t.Run(tt.name, func(t *testing.T) {
+			for _, d := range tt.data {
+				if d.clientErr != nil {
+					mockClient.SetError(d.clientErr)
+					assert.Error(t, tt.s.updateServiceInfo())
+					continue
+				}
+				if d.in != "" {
+					assert.NoError(t, mockClient.Load(d.in))
+				}
+				if d.expect != "" {
+					assertHandler.Reset()
+					assert.NoError(t, assertHandler.LoadExpected(d.expect))
+				}
+				assert.NoError(t, tt.s.updateServiceInfo())
+				assertHandler.Assert(t)
+			}
+		})
+	}
+}

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/eureka/testdata/legacy_gateway_mode.expected.yaml
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/eureka/testdata/legacy_gateway_mode.expected.yaml
@@ -1,0 +1,54 @@
+---
+kind: ServiceEntry
+apiVersion: networking.istio.io/v1alpha3
+metadata:
+  name: applicationa.eureka
+  namespace: eureka
+  labels:
+    registry: eureka
+  annotations: {}
+spec:
+  hosts:
+    - applicationa.eureka
+  ports:
+    - number: 80
+      protocol: HTTP
+      name: http-80
+  resolution: STATIC
+  endpoints:
+    - address: 192.168.2.10
+      ports:
+        http-80: 8000
+      labels:
+        version: 2.1.0
+        zone: eu-west-1a
+    - address: 192.168.2.11
+      ports:
+        http-80: 8001
+      labels:
+        version: 2.1.0
+        zone: eu-west-1b
+---
+kind: ServiceEntry
+apiVersion: networking.istio.io/v1alpha3
+metadata:
+  name: applicationb.eureka
+  namespace: eureka
+  labels:
+    registry: eureka
+  annotations: {}
+spec:
+  hosts:
+    - applicationb.eureka
+  ports:
+    - number: 80
+      protocol: HTTP
+      name: http-80
+  resolution: STATIC
+  endpoints:
+    - address: 192.168.3.10
+      ports:
+        http-80: 9000
+      labels:
+        version: 1.2.0
+        zone: ap-southeast-1a

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/eureka/testdata/legacy_gateway_mode.json
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/eureka/testdata/legacy_gateway_mode.json
@@ -1,0 +1,69 @@
+[
+    {
+      "name": "ApplicationA",
+      "instance": [
+        {
+          "instanceId": "appA-instance-1",
+          "hostName": "192.168.2.10",
+          "ipAddr": "192.168.2.10",
+          "status": "UP",
+          "port": {
+            "$": 8000,
+            "@enabled": "true"
+          },
+          "securePort": {
+            "$": 8443,
+            "@enabled": "false"
+          },
+          "app": "ApplicationA",
+          "metadata": {
+            "version": "2.1.0",
+            "zone": "eu-west-1a"
+          }
+        },
+        {
+          "instanceId": "appA-instance-2",
+          "hostName": "192.168.2.11",
+          "ipAddr": "192.168.2.11",
+          "status": "UP",
+          "port": {
+            "$": 8001,
+            "@enabled": "true"
+          },
+          "securePort": {
+            "$": 8444,
+            "@enabled": "false"
+          },
+          "app": "ApplicationA",
+          "metadata": {
+            "version": "2.1.0",
+            "zone": "eu-west-1b"
+          }
+        }
+      ]
+    },
+    {
+      "name": "ApplicationB",
+      "instance": [
+        {
+          "instanceId": "appB-instance-1",
+          "hostName": "192.168.3.10",
+          "ipAddr": "192.168.3.10",
+          "status": "UP",
+          "port": {
+            "$": 9000,
+            "@enabled": "true"
+          },
+          "securePort": {
+            "$": 9443,
+            "@enabled": "false"
+          },
+          "app": "ApplicationB",
+          "metadata": {
+            "version": "1.2.0",
+            "zone": "ap-southeast-1a"
+          }
+        }
+      ]
+    }
+  ]

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/eureka/testdata/project_code.expected.yaml
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/eureka/testdata/project_code.expected.yaml
@@ -1,0 +1,75 @@
+---
+kind: ServiceEntry
+apiVersion: networking.istio.io/v1alpha3
+metadata:
+  name: applicationa.nsf.project1.eureka
+  namespace: eureka
+  labels:
+    registry: eureka
+  annotations: {}
+spec:
+  hosts:
+    - applicationa.nsf.project1.eureka
+  ports:
+    - number: 80
+      protocol: HTTP
+      name: http-80
+  resolution: STATIC
+  endpoints:
+    - address: 192.168.2.10
+      ports:
+        http-80: 8000
+      labels:
+        projectCode: project1
+        version: 2.1.0
+        zone: eu-west-1a
+---
+kind: ServiceEntry
+apiVersion: networking.istio.io/v1alpha3
+metadata:
+  name: applicationa.nsf.project2.eureka
+  namespace: eureka
+  labels:
+    registry: eureka
+  annotations: {}
+spec:
+  hosts:
+    - applicationa.nsf.project2.eureka
+  ports:
+    - number: 80
+      protocol: HTTP
+      name: http-80
+  resolution: STATIC
+  endpoints:
+    - address: 192.168.2.11
+      ports:
+        http-80: 8001
+      labels:
+        projectCode: project2
+        version: 2.1.0
+        zone: eu-west-1b
+---
+kind: ServiceEntry
+apiVersion: networking.istio.io/v1alpha3
+metadata:
+  name: applicationb.nsf.project3.eureka
+  namespace: eureka
+  labels:
+    registry: eureka
+  annotations: {}
+spec:
+  hosts:
+    - applicationb.nsf.project3.eureka
+  ports:
+    - number: 80
+      protocol: HTTP
+      name: http-80
+  resolution: STATIC
+  endpoints:
+    - address: 192.168.3.10
+      ports:
+        http-80: 9000
+      labels:
+        projectCode: project3
+        version: 1.2.0
+        zone: ap-southeast-1a

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/eureka/testdata/project_code.json
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/eureka/testdata/project_code.json
@@ -1,0 +1,72 @@
+[
+    {
+      "name": "ApplicationA",
+      "instance": [
+        {
+          "instanceId": "appA-instance-1",
+          "hostName": "192.168.2.10",
+          "ipAddr": "192.168.2.10",
+          "status": "UP",
+          "port": {
+            "$": 8000,
+            "@enabled": "true"
+          },
+          "securePort": {
+            "$": 8443,
+            "@enabled": "false"
+          },
+          "app": "ApplicationA",
+          "metadata": {
+            "version": "2.1.0",
+            "zone": "eu-west-1a",
+            "projectCode": "project1"
+          }
+        },
+        {
+          "instanceId": "appA-instance-2",
+          "hostName": "192.168.2.11",
+          "ipAddr": "192.168.2.11",
+          "status": "UP",
+          "port": {
+            "$": 8001,
+            "@enabled": "true"
+          },
+          "securePort": {
+            "$": 8444,
+            "@enabled": "false"
+          },
+          "app": "ApplicationA",
+          "metadata": {
+            "version": "2.1.0",
+            "zone": "eu-west-1b",
+            "projectCode": "project2"
+          }
+        }
+      ]
+    },
+    {
+      "name": "ApplicationB",
+      "instance": [
+        {
+          "instanceId": "appB-instance-1",
+          "hostName": "192.168.3.10",
+          "ipAddr": "192.168.3.10",
+          "status": "UP",
+          "port": {
+            "$": 9000,
+            "@enabled": "true"
+          },
+          "securePort": {
+            "$": 9443,
+            "@enabled": "false"
+          },
+          "app": "ApplicationB",
+          "metadata": {
+            "version": "1.2.0",
+            "zone": "ap-southeast-1a",
+            "projectCode": "project3"
+          }
+        }
+      ]
+    }
+  ]

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/eureka/testdata/simple.expected.yaml
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/eureka/testdata/simple.expected.yaml
@@ -1,0 +1,59 @@
+---
+kind: ServiceEntry
+apiVersion: networking.istio.io/v1alpha3
+metadata:
+  name: applicationa
+  namespace: eureka
+  labels:
+    registry: eureka
+  annotations: {}
+spec:
+  hosts:
+    - applicationa
+  ports:
+    - number: 8000
+      protocol: HTTP
+      name: http-8000
+    - number: 8001
+      protocol: HTTP
+      name: http-8001
+  resolution: STATIC
+  endpoints:
+    - address: 192.168.2.10
+      ports:
+        http-8000: 8000
+        http-8001: 8000
+      labels:
+        version: 2.1.0
+        zone: eu-west-1a
+    - address: 192.168.2.11
+      ports:
+        http-8000: 8001
+        http-8001: 8001
+      labels:
+        version: 2.1.0
+        zone: eu-west-1b
+---
+kind: ServiceEntry
+apiVersion: networking.istio.io/v1alpha3
+metadata:
+  name: applicationb
+  namespace: eureka
+  labels:
+    registry: eureka
+  annotations: {}
+spec:
+  hosts:
+    - applicationb
+  ports:
+    - number: 9000
+      protocol: HTTP
+      name: http-9000
+  resolution: STATIC
+  endpoints:
+    - address: 192.168.3.10
+      ports:
+        http-9000: 9000
+      labels:
+        version: 1.2.0
+        zone: ap-southeast-1a

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/eureka/testdata/simple.json
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/eureka/testdata/simple.json
@@ -1,0 +1,88 @@
+[
+    {
+      "name": "ApplicationA",
+      "instance": [
+        {
+          "instanceId": "appA-instance-1",
+          "hostName": "192.168.2.10",
+          "ipAddr": "192.168.2.10",
+          "status": "UP",
+          "port": {
+            "$": 8000,
+            "@enabled": "true"
+          },
+          "securePort": {
+            "$": 8443,
+            "@enabled": "false"
+          },
+          "app": "ApplicationA",
+          "metadata": {
+            "version": "2.1.0",
+            "zone": "eu-west-1a"
+          }
+        },
+        {
+          "instanceId": "appA-instance-2",
+          "hostName": "192.168.2.11",
+          "ipAddr": "192.168.2.11",
+          "status": "UP",
+          "port": {
+            "$": 8001,
+            "@enabled": "true"
+          },
+          "securePort": {
+            "$": 8444,
+            "@enabled": "false"
+          },
+          "app": "ApplicationA",
+          "metadata": {
+            "version": "2.1.0",
+            "zone": "eu-west-1b"
+          }
+        },
+        {
+          "instanceId": "appA-instance-3",
+          "hostName": "192.168.2.12",
+          "ipAddr": "192.168.2.12",
+          "status": "DOWN",
+          "port": {
+            "$": 8001,
+            "@enabled": "true"
+          },
+          "securePort": {
+            "$": 8444,
+            "@enabled": "false"
+          },
+          "app": "ApplicationA",
+          "metadata": {
+            "version": "2.1.0",
+            "zone": "eu-west-1b"
+          }
+        }
+      ]
+    },
+    {
+      "name": "ApplicationB",
+      "instance": [
+        {
+          "instanceId": "appB-instance-1",
+          "hostName": "192.168.3.10",
+          "ipAddr": "192.168.3.10",
+          "status": "UP",
+          "port": {
+            "$": 9000,
+            "@enabled": "true"
+          },
+          "securePort": {
+            "$": 9443,
+            "@enabled": "false"
+          },
+          "app": "ApplicationB",
+          "metadata": {
+            "version": "1.2.0",
+            "zone": "ap-southeast-1a"
+          }
+        }
+      ]
+    }
+  ]

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/eureka/testdata/simple_scale_down_instance.expected.yaml
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/eureka/testdata/simple_scale_down_instance.expected.yaml
@@ -1,0 +1,41 @@
+---
+kind: ServiceEntry
+apiVersion: networking.istio.io/v1alpha3
+metadata:
+  name: applicationa
+  namespace: eureka
+  labels:
+    registry: eureka
+  annotations: {}
+spec:
+  hosts:
+    - applicationa
+  ports:
+    - number: 8000
+      protocol: HTTP
+      name: http-8000
+  resolution: STATIC
+  endpoints:
+    - address: 192.168.2.10
+      ports:
+        http-8000: 8000
+      labels:
+        version: 2.1.0
+        zone: eu-west-1a
+---
+kind: ServiceEntry
+apiVersion: networking.istio.io/v1alpha3
+metadata:
+  name: applicationb
+  namespace: eureka
+  labels:
+    registry: eureka
+  annotations: {}
+spec:
+  hosts:
+    - applicationb
+  ports:
+    - number: 9000
+      protocol: HTTP
+      name: http-9000
+  resolution: STATIC

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/eureka/testdata/simple_scale_down_instance.json
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/eureka/testdata/simple_scale_down_instance.json
@@ -1,0 +1,88 @@
+[
+    {
+      "name": "ApplicationA",
+      "instance": [
+        {
+          "instanceId": "appA-instance-1",
+          "hostName": "192.168.2.10",
+          "ipAddr": "192.168.2.10",
+          "status": "UP",
+          "port": {
+            "$": 8000,
+            "@enabled": "true"
+          },
+          "securePort": {
+            "$": 8443,
+            "@enabled": "false"
+          },
+          "app": "ApplicationA",
+          "metadata": {
+            "version": "2.1.0",
+            "zone": "eu-west-1a"
+          }
+        },
+        {
+          "instanceId": "appA-instance-2",
+          "hostName": "192.168.2.11",
+          "ipAddr": "192.168.2.11",
+          "status": "DOWN",
+          "port": {
+            "$": 8001,
+            "@enabled": "true"
+          },
+          "securePort": {
+            "$": 8444,
+            "@enabled": "false"
+          },
+          "app": "ApplicationA",
+          "metadata": {
+            "version": "2.1.0",
+            "zone": "eu-west-1b"
+          }
+        },
+        {
+          "instanceId": "appA-instance-3",
+          "hostName": "192.168.2.12",
+          "ipAddr": "192.168.2.12",
+          "status": "DOWN",
+          "port": {
+            "$": 8002,
+            "@enabled": "true"
+          },
+          "securePort": {
+            "$": 8444,
+            "@enabled": "false"
+          },
+          "app": "ApplicationA",
+          "metadata": {
+            "version": "2.1.0",
+            "zone": "eu-west-1b"
+          }
+        }
+      ]
+    },
+    {
+      "name": "ApplicationB",
+      "instance": [
+        {
+          "instanceId": "appB-instance-1",
+          "hostName": "192.168.3.10",
+          "ipAddr": "192.168.3.10",
+          "status": "DOWN",
+          "port": {
+            "$": 9000,
+            "@enabled": "true"
+          },
+          "securePort": {
+            "$": 9443,
+            "@enabled": "false"
+          },
+          "app": "ApplicationB",
+          "metadata": {
+            "version": "1.2.0",
+            "zone": "ap-southeast-1a"
+          }
+        }
+      ]
+    }
+  ]

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/nacos/mock_client.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/nacos/mock_client.go
@@ -1,0 +1,17 @@
+package nacos
+
+import "slime.io/slime/modules/meshregistry/pkg/source/sourcetest"
+
+var _ Client = (*MockClient)(nil)
+
+type MockClient struct {
+	sourcetest.MockPollingClient[instanceResp]
+}
+
+func (m *MockClient) Instances() ([]*instanceResp, error) {
+	return m.Services()
+}
+
+func (m *MockClient) RegistryInfo() string {
+	return m.MockPollingClient.RegistryInfo()
+}

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/nacos/polling.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/nacos/polling.go
@@ -40,7 +40,7 @@ func (s *Source) refresh() {
 	log.Infof("nacos refresh start : %d", t0.UnixNano())
 	if err := s.updateServiceInfo(); err != nil {
 		monitoring.RecordPolling(SourceName, t0, time.Now(), false)
-		log.Errorf("eureka update service info failed: %v", err)
+		log.Errorf("nacos update service info failed: %v", err)
 		return
 	}
 	t1 := time.Now()

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/nacos/source_test.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/nacos/source_test.go
@@ -123,6 +123,7 @@ func TestUpdateServiceInfo(t *testing.T) {
 		// - hostalias
 		// - ServiceEntry meta modifier
 		// - regroup instances
+		// - mock merged ServiceEntry
 		// - ...
 	}
 

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/nacos/source_test.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/nacos/source_test.go
@@ -1,0 +1,157 @@
+package nacos
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"slime.io/slime/modules/meshregistry/pkg/bootstrap"
+	"slime.io/slime/modules/meshregistry/pkg/source/sourcetest"
+)
+
+var emptySeMetaModifierFactory = generateSeMetaModifierFactory(map[string]*bootstrap.MetadataWrapper{})
+
+func TestUpdateServiceInfo(t *testing.T) {
+	type testData struct {
+		// clientErr is the error returned by the mock client
+		clientErr error
+		// in is the json format input file path
+		in string
+		// expect is the yaml format expected file path
+		expect string
+	}
+	assertHandler := sourcetest.NewAssertEventHandler()
+	mockClient := &MockClient{}
+	args := []struct {
+		name           string
+		data           []testData
+		s              *Source
+		enableFeatures func()
+	}{
+		{
+			name: "simple",
+			data: []testData{
+				{
+					in:     "./testdata/simple.json",
+					expect: "./testdata/simple.expected.yaml",
+				},
+			},
+			s: &Source{
+				args: &bootstrap.NacosSourceArgs{
+					SourceArgs: bootstrap.SourceArgs{
+						SvcProtocol:           "http",
+						InstancePortAsSvcPort: true,
+						ResourceNs:            "nacos",
+						DefaultServiceNs:      "nacos",
+					},
+				},
+				seMetaModifierFactory: emptySeMetaModifierFactory,
+			},
+		},
+		{
+			name: "simple-scale-down-instance",
+			data: []testData{
+				{
+					in:     "./testdata/simple.json",
+					expect: "./testdata/simple.expected.yaml",
+				},
+				{
+					in:     "./testdata/simple_scale_down_instance.json",
+					expect: "./testdata/simple_scale_down_instance.expected.yaml",
+				},
+			},
+			s: &Source{
+				args: &bootstrap.NacosSourceArgs{
+					SourceArgs: bootstrap.SourceArgs{
+						SvcProtocol:           "http",
+						InstancePortAsSvcPort: true,
+						ResourceNs:            "nacos",
+						DefaultServiceNs:      "nacos",
+					},
+				},
+				seMetaModifierFactory: emptySeMetaModifierFactory,
+			},
+		},
+		{
+			name: "legacy_gateway_mode",
+			data: []testData{
+				{
+					in:     "./testdata/legacy_gateway_mode.json",
+					expect: "./testdata/legacy_gateway_mode.expected.yaml",
+				},
+			},
+			s: &Source{
+				args: &bootstrap.NacosSourceArgs{
+					SourceArgs: bootstrap.SourceArgs{
+						SvcProtocol:           "http",
+						SvcPort:               80,
+						InstancePortAsSvcPort: false,
+						ResourceNs:            "nacos",
+						DefaultServiceNs:      "nacos",
+					},
+					NsHost: true,
+				},
+				seMetaModifierFactory: emptySeMetaModifierFactory,
+			},
+		},
+		{
+			name: "enable-project-code",
+			data: []testData{
+				{
+					in:     "./testdata/project_code.json",
+					expect: "./testdata/project_code.expected.yaml",
+				},
+			},
+			s: &Source{
+				args: &bootstrap.NacosSourceArgs{
+					SourceArgs: bootstrap.SourceArgs{
+						SvcProtocol:           "http",
+						SvcPort:               80,
+						InstancePortAsSvcPort: false,
+						ResourceNs:            "nacos",
+						DefaultServiceNs:      "nacos",
+					},
+					NsHost:            true,
+					EnableProjectCode: true,
+					DomSuffix:         "nsf",
+				},
+				seMetaModifierFactory: emptySeMetaModifierFactory,
+			},
+		},
+		// TODO: add test cases for:
+		// - instance filter
+		// - hostalias
+		// - ServiceEntry meta modifier
+		// - regroup instances
+		// - ...
+	}
+
+	initTest := func(s *Source) {
+		mockClient.Reset()
+		s.client = mockClient
+		assertHandler.Reset()
+		s.Dispatch(assertHandler)
+	}
+
+	for _, tt := range args {
+		initTest(tt.s)
+		t.Run(tt.name, func(t *testing.T) {
+			for _, d := range tt.data {
+				if d.clientErr != nil {
+					mockClient.SetError(d.clientErr)
+					assert.Error(t, tt.s.updateServiceInfo())
+					continue
+				}
+				if d.in != "" {
+					assert.NoError(t, mockClient.Load(d.in))
+				}
+				if d.expect != "" {
+					assertHandler.Reset()
+					assert.NoError(t, assertHandler.LoadExpected(d.expect))
+				}
+				assert.NoError(t, tt.s.updateServiceInfo())
+				assertHandler.Assert(t)
+			}
+		})
+	}
+}

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/nacos/testdata/legacy_gateway_mode.expected.yaml
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/nacos/testdata/legacy_gateway_mode.expected.yaml
@@ -1,0 +1,54 @@
+---
+kind: ServiceEntry
+apiVersion: networking.istio.io/v1alpha3
+metadata:
+  name: service-a.nacos
+  namespace: nacos
+  labels:
+    registry: nacos
+  annotations: {}
+spec:
+  hosts:
+    - service-a.nacos
+  ports:
+    - number: 80
+      protocol: HTTP
+      name: http-80
+  resolution: STATIC
+  endpoints:
+    - address: 10.0.0.1
+      ports:
+        http-80: 8080
+      labels:
+        environment: test
+        version: v1
+    - address: 10.0.0.2
+      ports:
+        http-80: 8080
+      labels:
+        environment: test
+        version: v2
+---
+kind: ServiceEntry
+apiVersion: networking.istio.io/v1alpha3
+metadata:
+  name: service-b.nacos
+  namespace: nacos
+  labels:
+    registry: nacos
+  annotations: {}
+spec:
+  hosts:
+    - service-b.nacos
+  ports:
+    - number: 80
+      protocol: HTTP
+      name: http-80
+  resolution: STATIC
+  endpoints:
+    - address: 10.0.1.1
+      ports:
+        http-80: 9000
+      labels:
+        environment: test
+        version: v1

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/nacos/testdata/legacy_gateway_mode.json
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/nacos/testdata/legacy_gateway_mode.json
@@ -1,0 +1,54 @@
+[
+    {
+        "hosts": [
+            {
+                "instanceId": "10.0.0.1#8080#DEFAULT#DEFAULT_GROUP@@service-a",
+                "ip": "10.0.0.1",
+                "port": 8080,
+                "healthy": true,
+                "enabled": true,
+                "ephemeral": true,
+                "clusterName": "DEFAULT",
+                "serviceName": "DEFAULT_GROUP@@service-a",
+                "metadata": {
+                    "environment": "test",
+                    "version": "v1"
+                }
+            },
+            {
+                "instanceId": "10.0.0.2#8080#DEFAULT#DEFAULT_GROUP@@service-a",
+                "ip": "10.0.0.2",
+                "port": 8080,
+                "healthy": true,
+                "enabled": true,
+                "ephemeral": true,
+                "clusterName": "DEFAULT",
+                "serviceName": "DEFAULT_GROUP@@service-a",
+                "metadata": {
+                    "environment": "test",
+                    "version": "v2"
+                }
+            }
+        ],
+        "dom": "service-a"
+    },
+    {
+        "hosts": [
+            {
+                "instanceId": "10.0.1.1#9000#DEFAULT#DEFAULT_GROUP@@service-b",
+                "ip": "10.0.1.1",
+                "port": 9000,
+                "healthy": true,
+                "enabled": true,
+                "ephemeral": true,
+                "clusterName": "DEFAULT",
+                "serviceName": "DEFAULT_GROUP@@service-b",
+                "metadata": {
+                    "environment": "test",
+                    "version": "v1"
+                }
+            }
+        ],
+        "dom": "service-b"
+    }
+]

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/nacos/testdata/project_code.expected.yaml
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/nacos/testdata/project_code.expected.yaml
@@ -1,0 +1,75 @@
+---
+kind: ServiceEntry
+apiVersion: networking.istio.io/v1alpha3
+metadata:
+  name: service-a.nsf.project1.nacos
+  namespace: nacos
+  labels:
+    registry: nacos
+  annotations: {}
+spec:
+  hosts:
+    - service-a.nsf.project1.nacos
+  ports:
+    - number: 80
+      protocol: HTTP
+      name: http-80
+  resolution: STATIC
+  endpoints:
+    - address: 10.0.0.1
+      ports:
+        http-80: 8080
+      labels:
+        environment: test
+        version: v1
+        projectCode: project1
+---
+kind: ServiceEntry
+apiVersion: networking.istio.io/v1alpha3
+metadata:
+  name: service-a.nsf.project2.nacos
+  namespace: nacos
+  labels:
+    registry: nacos
+  annotations: {}
+spec:
+  hosts:
+    - service-a.nsf.project2.nacos
+  ports:
+    - number: 80
+      protocol: HTTP
+      name: http-80
+  resolution: STATIC
+  endpoints:
+    - address: 10.0.0.2
+      ports:
+        http-80: 8080
+      labels:
+        environment: test
+        version: v2
+        projectCode: project2
+---
+kind: ServiceEntry
+apiVersion: networking.istio.io/v1alpha3
+metadata:
+  name: service-b.nsf.project1.nacos
+  namespace: nacos
+  labels:
+    registry: nacos
+  annotations: {}
+spec:
+  hosts:
+    - service-b.nsf.project1.nacos
+  ports:
+    - number: 80
+      protocol: HTTP
+      name: http-80
+  resolution: STATIC
+  endpoints:
+    - address: 10.0.1.1
+      ports:
+        http-80: 9000
+      labels:
+        environment: test
+        version: v1
+        projectCode: project1

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/nacos/testdata/project_code.json
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/nacos/testdata/project_code.json
@@ -1,0 +1,57 @@
+[
+    {
+        "hosts": [
+            {
+                "instanceId": "10.0.0.1#8080#DEFAULT#DEFAULT_GROUP@@service-a",
+                "ip": "10.0.0.1",
+                "port": 8080,
+                "healthy": true,
+                "enabled": true,
+                "ephemeral": true,
+                "clusterName": "DEFAULT",
+                "serviceName": "DEFAULT_GROUP@@service-a",
+                "metadata": {
+                    "environment": "test",
+                    "version": "v1",
+                    "projectCode": "project1"
+                }
+            },
+            {
+                "instanceId": "10.0.0.2#8080#DEFAULT#DEFAULT_GROUP@@service-a",
+                "ip": "10.0.0.2",
+                "port": 8080,
+                "healthy": true,
+                "enabled": true,
+                "ephemeral": true,
+                "clusterName": "DEFAULT",
+                "serviceName": "DEFAULT_GROUP@@service-a",
+                "metadata": {
+                    "environment": "test",
+                    "version": "v2",
+                    "projectCode": "project2"
+                }
+            }
+        ],
+        "dom": "service-a"
+    },
+    {
+        "hosts": [
+            {
+                "instanceId": "10.0.1.1#9000#DEFAULT#DEFAULT_GROUP@@service-b",
+                "ip": "10.0.1.1",
+                "port": 9000,
+                "healthy": true,
+                "enabled": true,
+                "ephemeral": true,
+                "clusterName": "DEFAULT",
+                "serviceName": "DEFAULT_GROUP@@service-b",
+                "metadata": {
+                    "environment": "test",
+                    "version": "v1",
+                    "projectCode": "project1"
+                }
+            }
+        ],
+        "dom": "service-b"
+    }
+]

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/nacos/testdata/simple.expected.yaml
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/nacos/testdata/simple.expected.yaml
@@ -1,0 +1,54 @@
+---
+kind: ServiceEntry
+apiVersion: networking.istio.io/v1alpha3
+metadata:
+  name: service-a
+  namespace: nacos
+  labels:
+    registry: nacos
+  annotations: {}
+spec:
+  hosts:
+    - service-a
+  ports:
+    - number: 8080
+      protocol: HTTP
+      name: http-8080
+  resolution: STATIC
+  endpoints:
+    - address: 10.0.0.1
+      ports:
+        http-8080: 8080
+      labels:
+        environment: test
+        version: v1
+    - address: 10.0.0.2
+      ports:
+        http-8080: 8080
+      labels:
+        environment: test
+        version: v2
+---
+kind: ServiceEntry
+apiVersion: networking.istio.io/v1alpha3
+metadata:
+  name: service-b
+  namespace: nacos
+  labels:
+    registry: nacos
+  annotations: {}
+spec:
+  hosts:
+    - service-b
+  ports:
+    - number: 9000
+      protocol: HTTP
+      name: http-9000
+  resolution: STATIC
+  endpoints:
+    - address: 10.0.1.1
+      ports:
+        http-9000: 9000
+      labels:
+        environment: test
+        version: v1

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/nacos/testdata/simple.json
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/nacos/testdata/simple.json
@@ -1,0 +1,68 @@
+[
+    {
+        "hosts": [
+            {
+                "instanceId": "10.0.0.1#8080#DEFAULT#DEFAULT_GROUP@@service-a",
+                "ip": "10.0.0.1",
+                "port": 8080,
+                "healthy": true,
+                "enabled": true,
+                "ephemeral": true,
+                "clusterName": "DEFAULT",
+                "serviceName": "DEFAULT_GROUP@@service-a",
+                "metadata": {
+                    "environment": "test",
+                    "version": "v1"
+                }
+            },
+            {
+                "instanceId": "10.0.0.2#8080#DEFAULT#DEFAULT_GROUP@@service-a",
+                "ip": "10.0.0.2",
+                "port": 8080,
+                "healthy": true,
+                "enabled": true,
+                "ephemeral": true,
+                "clusterName": "DEFAULT",
+                "serviceName": "DEFAULT_GROUP@@service-a",
+                "metadata": {
+                    "environment": "test",
+                    "version": "v2"
+                }
+            },
+            {
+                "instanceId": "10.0.0.3#8080#DEFAULT#DEFAULT_GROUP@@service-a",
+                "ip": "10.0.0.3",
+                "port": 8080,
+                "healthy": false,
+                "enabled": true,
+                "ephemeral": true,
+                "clusterName": "DEFAULT",
+                "serviceName": "DEFAULT_GROUP@@service-a",
+                "metadata": {
+                    "environment": "test",
+                    "version": "v3"
+                }
+            }
+        ],
+        "dom": "service-a"
+    },
+    {
+        "hosts": [
+            {
+                "instanceId": "10.0.1.1#9000#DEFAULT#DEFAULT_GROUP@@service-b",
+                "ip": "10.0.1.1",
+                "port": 9000,
+                "healthy": true,
+                "enabled": true,
+                "ephemeral": true,
+                "clusterName": "DEFAULT",
+                "serviceName": "DEFAULT_GROUP@@service-b",
+                "metadata": {
+                    "environment": "test",
+                    "version": "v1"
+                }
+            }
+        ],
+        "dom": "service-b"
+    }
+]

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/nacos/testdata/simple_scale_down_instance.expected.yaml
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/nacos/testdata/simple_scale_down_instance.expected.yaml
@@ -1,0 +1,41 @@
+---
+kind: ServiceEntry
+apiVersion: networking.istio.io/v1alpha3
+metadata:
+  name: service-a
+  namespace: nacos
+  labels:
+    registry: nacos
+  annotations: {}
+spec:
+  hosts:
+    - service-a
+  ports:
+    - number: 8080
+      protocol: HTTP
+      name: http-8080
+  resolution: STATIC
+  endpoints:
+    - address: 10.0.0.1
+      ports:
+        http-8080: 8080
+      labels:
+        environment: test
+        version: v1
+---
+kind: ServiceEntry
+apiVersion: networking.istio.io/v1alpha3
+metadata:
+  name: service-b
+  namespace: nacos
+  labels:
+    registry: nacos
+  annotations: {}
+spec:
+  hosts:
+    - service-b
+  ports:
+    - number: 9000
+      protocol: HTTP
+      name: http-9000
+  resolution: STATIC

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/nacos/testdata/simple_scale_down_instance.json
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/nacos/testdata/simple_scale_down_instance.json
@@ -1,0 +1,68 @@
+[
+    {
+        "hosts": [
+            {
+                "instanceId": "10.0.0.1#8080#DEFAULT#DEFAULT_GROUP@@service-a",
+                "ip": "10.0.0.1",
+                "port": 8080,
+                "healthy": true,
+                "enabled": true,
+                "ephemeral": true,
+                "clusterName": "DEFAULT",
+                "serviceName": "DEFAULT_GROUP@@service-a",
+                "metadata": {
+                    "environment": "test",
+                    "version": "v1"
+                }
+            },
+            {
+                "instanceId": "10.0.0.2#8080#DEFAULT#DEFAULT_GROUP@@service-a",
+                "ip": "10.0.0.2",
+                "port": 8080,
+                "healthy": false,
+                "enabled": true,
+                "ephemeral": true,
+                "clusterName": "DEFAULT",
+                "serviceName": "DEFAULT_GROUP@@service-a",
+                "metadata": {
+                    "environment": "test",
+                    "version": "v2"
+                }
+            },
+            {
+                "instanceId": "10.0.0.3#8080#DEFAULT#DEFAULT_GROUP@@service-a",
+                "ip": "10.0.0.3",
+                "port": 8080,
+                "healthy": false,
+                "enabled": true,
+                "ephemeral": true,
+                "clusterName": "DEFAULT",
+                "serviceName": "DEFAULT_GROUP@@service-a",
+                "metadata": {
+                    "environment": "test",
+                    "version": "v3"
+                }
+            }
+        ],
+        "dom": "service-a"
+    },
+    {
+        "hosts": [
+            {
+                "instanceId": "10.0.1.1#9000#DEFAULT#DEFAULT_GROUP@@service-b",
+                "ip": "10.0.1.1",
+                "port": 9000,
+                "healthy": false,
+                "enabled": true,
+                "ephemeral": true,
+                "clusterName": "DEFAULT",
+                "serviceName": "DEFAULT_GROUP@@service-b",
+                "metadata": {
+                    "environment": "test",
+                    "version": "v1"
+                }
+            }
+        ],
+        "dom": "service-b"
+    }
+]

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/sourcetest/source.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/sourcetest/source.go
@@ -1,0 +1,215 @@
+package sourcetest
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"istio.io/libistio/pkg/config"
+	"istio.io/libistio/pkg/config/event"
+	"istio.io/libistio/pkg/config/resource"
+	"istio.io/libistio/pkg/config/schema/collection"
+	"istio.io/libistio/pkg/config/schema/collections"
+	"istio.io/libistio/pkg/config/source/kube/file"
+)
+
+// simpleConfigStore is a simple in-memory config store that stores configs in a map.
+// It is not thread-safe, and is only used for testing.
+type simpleConfigStore struct {
+	// snaps is a map of group version kind to a map of namespace/name to config.Config
+	snaps map[config.GroupVersionKind]map[string]config.Config
+}
+
+// set sets the config for the given group version kind and namespace/name.
+func (s *simpleConfigStore) set(cfg config.Config) {
+	if s.snaps[cfg.GroupVersionKind] == nil {
+		s.snaps[cfg.GroupVersionKind] = make(map[string]config.Config)
+	}
+	s.snaps[cfg.GroupVersionKind][cfg.Meta.Namespace+"/"+cfg.Meta.Name] = cfg
+}
+
+// remove removes the config for the given group version kind and namespace/name.
+func (s *simpleConfigStore) remove(gvk config.GroupVersionKind, ns, name string) {
+	delete(s.snaps[gvk], ns+"/"+name)
+}
+
+// listByGVK returns the configs for the given group version kind.
+func (s *simpleConfigStore) listByGVK(gvk config.GroupVersionKind) map[string]config.Config {
+	return s.snaps[gvk]
+}
+
+// clear clears the config store.
+func (s *simpleConfigStore) clear() {
+	s.snaps = make(map[config.GroupVersionKind]map[string]config.Config)
+}
+
+func (s *simpleConfigStore) Handle(e event.Event) {
+	switch e.Kind {
+	case event.Added, event.Updated:
+		s.set(convertResourceToConfig(e.Source.GroupVersionKind(), e.Resource))
+	case event.Deleted:
+		ns, name := e.Resource.Metadata.FullName.Namespace.String(), e.Resource.Metadata.FullName.Name.String()
+		s.remove(e.Source.GroupVersionKind(), ns, name)
+	default:
+		// do nothing
+	}
+}
+
+type AssertEventHandler struct {
+	schemas collection.Schemas
+
+	expected       *simpleConfigStore
+	expectedHelper *file.KubeSource
+
+	got *simpleConfigStore
+}
+
+func NewAssertEventHandler() *AssertEventHandler {
+	schemas := collection.SchemasFor(collections.ServiceEntry, collections.Sidecar)
+	expected := &simpleConfigStore{
+		snaps: map[config.GroupVersionKind]map[string]config.Config{},
+	}
+	helper := file.NewKubeSource(schemas)
+	helper.Dispatch(expected)
+	helper.Start()
+
+	return &AssertEventHandler{
+		schemas:        schemas,
+		expected:       expected,
+		expectedHelper: helper,
+		got: &simpleConfigStore{
+			snaps: map[config.GroupVersionKind]map[string]config.Config{},
+		},
+	}
+}
+
+func (h *AssertEventHandler) Handle(e event.Event) {
+	h.got.Handle(e)
+}
+
+func (h *AssertEventHandler) LoadExpected(path string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	return h.expectedHelper.ApplyContent(path, string(data))
+}
+
+func (h *AssertEventHandler) Reset() {
+	h.expected.clear()
+	h.expectedHelper.Clear()
+	h.got.clear()
+}
+
+func (h *AssertEventHandler) Assert(t *testing.T) {
+	for _, schema := range h.schemas.All() {
+		expected := h.expected.listByGVK(schema.GroupVersionKind())
+		got := h.got.listByGVK(schema.GroupVersionKind())
+		assert.Equal(t, len(expected), len(got))
+		for nn, expectCfg := range expected {
+			gotCfg, exist := got[nn]
+			if assert.Truef(t, exist, "expected config %s not found", nn) {
+				assert.Equal(t, expectCfg.Meta.Labels, gotCfg.Meta.Labels)
+				assert.Equal(t, expectCfg.Meta.Annotations, gotCfg.Meta.Annotations)
+				expectSpecJson, _ := config.ToJSON(expectCfg.Spec)
+				gotSpecJson, _ := config.ToJSON(gotCfg.Spec)
+				assert.JSONEq(t, string(expectSpecJson), string(gotSpecJson))
+			}
+		}
+	}
+}
+
+func (h *AssertEventHandler) DumpGot() {
+	for _, schema := range h.schemas.All() {
+		got := h.got.listByGVK(schema.GroupVersionKind())
+		for _, cfg := range got {
+			b, _ := json.Marshal(cfg)
+			fmt.Println(string(b))
+		}
+	}
+}
+
+// convertResourceToConfig converts a resource.Instance to a config.Config.
+func convertResourceToConfig(gvk config.GroupVersionKind, res *resource.Instance) config.Config {
+	// Do not store the CreationTimestamp and ResourceVersion, because
+	// we are only interested in the labels and the spec for testing.
+	return config.Config{
+		Meta: config.Meta{
+			GroupVersionKind: gvk,
+			Name:             res.Metadata.FullName.Name.String(),
+			Namespace:        res.Metadata.FullName.Namespace.String(),
+			Labels:           res.Metadata.Labels,
+			Annotations:      res.Metadata.Annotations,
+		},
+		Spec: res.Message,
+	}
+}
+
+// MockPollingClient is a mock polling client that loads services from a JSON file.
+// It is used to test the polling mode source.
+type MockPollingClient[T any] struct {
+	err      error
+	services []*T
+	path     string
+}
+
+// Services returns the list of T and an error.
+// If the error is not nil, it will return an empty list and the error.
+// If the error is nil, and the services list is not nil, it will return the services list and nil.
+// Otherwise, it will load the services from the JSON file and return them.
+func (m *MockPollingClient[T]) Services() ([]*T, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	if m.services != nil {
+		return m.services, nil
+	}
+	if err := m.load(); err != nil {
+		return nil, err
+	}
+	return m.services, nil
+}
+
+func (m *MockPollingClient[T]) RegistryInfo() string {
+	return "mock"
+}
+
+func (m *MockPollingClient[T]) Reset() {
+	m.err = nil
+	m.services = nil
+	m.path = ""
+}
+
+func (m *MockPollingClient[T]) SetError(err error) {
+	m.err = err
+}
+
+func (m *MockPollingClient[T]) SetServices(services []*T) {
+	m.services = services
+}
+
+func (m *MockPollingClient[T]) SetPath(path string) {
+	m.path = path
+}
+
+func (m *MockPollingClient[T]) Load(path string) error {
+	if path != "" {
+		m.SetPath(path)
+	}
+	return m.load()
+}
+
+func (m *MockPollingClient[T]) load() error {
+	data, err := os.ReadFile(m.path)
+	if err != nil {
+		return err
+	}
+	var apps []*T
+	if err := json.Unmarshal(data, &apps); err != nil {
+		return err
+	}
+	m.services = apps
+	return nil
+}

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/sourcetest/source_test.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/sourcetest/source_test.go
@@ -1,0 +1,110 @@
+package sourcetest
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestZkNode_GetChildren(t *testing.T) {
+	root := &ZkNode{
+		FullPath: "/",
+		Children: map[string]*ZkNode{
+			"a": {
+				FullPath: "/a",
+			},
+			"b": {
+				FullPath: "/b",
+				Children: map[string]*ZkNode{
+					"c": {
+						FullPath: "/b/c",
+					},
+				},
+			},
+			"bb": {
+				FullPath: "/bb",
+				Children: map[string]*ZkNode{
+					"cc": {
+						FullPath: "/bb/cc",
+					},
+				},
+			},
+			"d": {
+				FullPath: "/d",
+				Children: map[string]*ZkNode{
+					"dd": {
+						FullPath: "/d/dd",
+						Children: map[string]*ZkNode{
+							"ddd": {
+								FullPath: "/d/dd/ddd",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	type args struct {
+		path string
+	}
+	tests := []struct {
+		name string
+		args args
+		want []string
+	}{
+		{
+			name: "root",
+			args: args{
+				path: "/",
+			},
+			want: []string{
+				"a",
+				"b",
+				"bb",
+				"d",
+			},
+		},
+		{
+			name: "b",
+			args: args{
+				path: "/b",
+			},
+			want: []string{
+				"c",
+			},
+		},
+		{
+			name: "parent is exist, but has no children",
+			args: args{
+				path: "/a",
+			},
+			want: nil,
+		},
+		{
+			name: "parent is not exist",
+			args: args{
+				path: "/not_exist",
+			},
+			want: nil,
+		},
+		{
+			name: "deep path",
+			args: args{
+				path: "/d/dd",
+			},
+			want: []string{
+				"ddd",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := root.GetChildren(tt.args.path)
+			sort.Strings(got)
+			sort.Strings(tt.want)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ZkNode.GetChildren() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/zookeeper/mock_zk.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/zookeeper/mock_zk.go
@@ -1,0 +1,31 @@
+package zookeeper
+
+import (
+	"github.com/go-zookeeper/zk"
+
+	"slime.io/slime/modules/meshregistry/pkg/source/sourcetest"
+)
+
+var _ ZkConn = (*MockZkConn)(nil)
+
+type MockZkConn struct {
+	sourcetest.MockZookeeperClient
+}
+
+func (m *MockZkConn) Store(*zk.Conn) {}
+
+func (m *MockZkConn) Load() any {
+	return m.MockZookeeperClient
+}
+
+func (m *MockZkConn) Children(path string) ([]string, error) {
+	return m.MockZookeeperClient.Children(path)
+}
+
+func (m *MockZkConn) ChildrenW(path string) ([]string, <-chan zk.Event, error) {
+	return m.MockZookeeperClient.ChildrenW(path)
+}
+
+func (m *MockZkConn) LoadData(path string) error {
+	return m.MockZookeeperClient.Load(path)
+}

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/zookeeper/sidecar.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/zookeeper/sidecar.go
@@ -365,7 +365,7 @@ func convertDubboCallModel(
 		{eps: inboundEndpoints, inbound: true},
 	} {
 		for _, e := range it.eps {
-			app, ok := e.Labels[DubboSvcAppLabel]
+			app, ok := e.Labels[dubboSvcAppLabel]
 			if !ok {
 				continue
 			}

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/zookeeper/source_test.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/zookeeper/source_test.go
@@ -7,10 +7,16 @@ package zookeeper
 
 import (
 	"testing"
+	"time"
 
+	cmap "github.com/orcaman/concurrent-map/v2"
+	"github.com/stretchr/testify/assert"
+	"istio.io/libistio/pkg/config/resource"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"slime.io/slime/modules/meshregistry/pkg/bootstrap"
+	"slime.io/slime/modules/meshregistry/pkg/source"
+	"slime.io/slime/modules/meshregistry/pkg/source/sourcetest"
 )
 
 func Test_generateInstanceFilter(t *testing.T) {
@@ -80,6 +86,239 @@ func Test_generateInstanceFilter(t *testing.T) {
 			got := generateInstanceFilter(tt.args.svcSel, tt.args.epSel, tt.args.emptySelectorsReturn, tt.args.alwaysUseSourceScopedEpSelectors)
 			if got(tt.inst) != tt.want {
 				t.Errorf("generateInstanceFilter() = %v, want %v", got(tt.inst), tt.want)
+			}
+		})
+	}
+}
+
+func TestUpdateServiceInfo(t *testing.T) {
+	type testData struct {
+		// clientErr is the error returned by the mock client
+		clientErr error
+		// in is the yaml format input file path
+		in string
+		// expect is the yaml format expected file path
+		expect string
+	}
+
+	newSource := func(args *bootstrap.ZookeeperSourceArgs, opts ...func(*Source)) *Source {
+		s := &Source{
+			args:                 args,
+			serviceMethods:       map[string]string{},
+			seDubboCallModels:    map[resource.FullName]map[string]DubboCallModel{},
+			appSidecarUpdateTime: map[string]time.Time{},
+			registryServiceCache: cmap.New[cmap.ConcurrentMap[string, []dubboInstance]](),
+			cache:                cmap.New[cmap.ConcurrentMap[string, *ServiceEntryWithMeta]](),
+		}
+		if args.MockServiceEntryName != "" && args.MockServiceName != "" {
+			s.seMergePortMocker = source.NewServiceEntryMergePortMocker(
+				args.MockServiceEntryName, args.ResourceNs, args.MockServiceName,
+				args.MockServiceMergeInstancePort, args.MockServiceMergeServicePort,
+				map[string]string{
+					"path":     args.MockServiceName,
+					"registry": SourceName,
+				},
+			)
+			s.seMergePortMocker.SetDispatcher(s.dispatchMergePortsServiceEntry)
+			s.handlers = append(s.handlers, s.seMergePortMocker)
+		}
+
+		for _, opt := range opts {
+			opt(s)
+		}
+		return s
+	}
+
+	assertHandler := sourcetest.NewAssertEventHandler()
+	mockClient := &MockZkConn{}
+	args := []struct {
+		name string
+		data []testData
+		s    *Source
+	}{
+		{
+			name: "simple",
+			data: []testData{
+				{
+					in:     "./testdata/simple.yaml",
+					expect: "./testdata/simple.expected.yaml",
+				},
+			},
+			s: newSource(&bootstrap.ZookeeperSourceArgs{
+				SourceArgs: bootstrap.SourceArgs{
+					SvcProtocol:           "DUBBO",
+					InstancePortAsSvcPort: true,
+					ResourceNs:            "dubbo",
+					DefaultServiceNs:      "dubbo",
+				},
+				RegistryRootNode: "/dubbo",
+			}),
+		},
+		{
+			name: "simple_scale_down_instance",
+			data: []testData{
+				{
+					in:     "./testdata/simple.yaml",
+					expect: "./testdata/simple.expected.yaml",
+				},
+				{
+					in:     "./testdata/simple_scale_down_instance.yaml",
+					expect: "./testdata/simple_scale_down_instance.expected.yaml",
+				},
+			},
+			s: newSource(&bootstrap.ZookeeperSourceArgs{
+				SourceArgs: bootstrap.SourceArgs{
+					SvcProtocol:           "DUBBO",
+					InstancePortAsSvcPort: true,
+					ResourceNs:            "dubbo",
+					DefaultServiceNs:      "dubbo",
+				},
+				RegistryRootNode: "/dubbo",
+			}),
+		},
+		{
+			name: "simple_with_dubbo_call_model",
+			data: []testData{
+				{
+					in:     "./testdata/simple.yaml",
+					expect: "./testdata/simple_with_dubbo_call_model.expected.yaml",
+				},
+			},
+			s: newSource(&bootstrap.ZookeeperSourceArgs{
+				SourceArgs: bootstrap.SourceArgs{
+					SvcProtocol:           "DUBBO",
+					InstancePortAsSvcPort: true,
+					ResourceNs:            "dubbo",
+					DefaultServiceNs:      "dubbo",
+				},
+				RegistryRootNode:      "/dubbo",
+				ConsumerPath:          "/consumers",
+				EnableDubboSidecar:    true,
+				DubboWorkloadAppLabel: "application",
+			}),
+		},
+		{
+			name: "simple_with_dubbo_call_model_and_self_consume",
+			data: []testData{
+				{
+					in:     "./testdata/simple.yaml",
+					expect: "./testdata/simple_with_dubbo_call_model_and_self_consume.expected.yaml",
+				},
+			},
+			s: newSource(&bootstrap.ZookeeperSourceArgs{
+				SourceArgs: bootstrap.SourceArgs{
+					SvcProtocol:           "DUBBO",
+					InstancePortAsSvcPort: true,
+					ResourceNs:            "dubbo",
+					DefaultServiceNs:      "dubbo",
+				},
+				RegistryRootNode:      "/dubbo",
+				ConsumerPath:          "/consumers",
+				EnableDubboSidecar:    true,
+				SelfConsume:           true,
+				DubboWorkloadAppLabel: "application",
+			}),
+		},
+		{
+			name: "se_merge_port_mocker",
+			data: []testData{
+				{
+					in:     "./testdata/simple.yaml",
+					expect: "./testdata/simple_se_merge_port_mocker.expected.yaml",
+				},
+			},
+			s: newSource(&bootstrap.ZookeeperSourceArgs{
+				SourceArgs: bootstrap.SourceArgs{
+					SvcProtocol:                 "DUBBO",
+					InstancePortAsSvcPort:       true,
+					ResourceNs:                  "dubbo",
+					DefaultServiceNs:            "dubbo",
+					MockServiceName:             "not-really-exist-dubbo.svc",
+					MockServiceEntryName:        "not-really-exist-dubbo",
+					MockServiceMergeServicePort: true,
+				},
+				RegistryRootNode: "/dubbo",
+			}),
+		},
+		{
+			name: "legacy_gateway_mode",
+			data: []testData{
+				{
+					in:     "./testdata/legacy_gateway_mode.yaml",
+					expect: "./testdata/legacy_gateway_mode.expected.yaml",
+				},
+			},
+			s: newSource(&bootstrap.ZookeeperSourceArgs{
+				SourceArgs: bootstrap.SourceArgs{
+					SvcProtocol:           "http",
+					SvcPort:               80,
+					InstancePortAsSvcPort: false,
+					ResourceNs:            "dubbo",
+					DefaultServiceNs:      "dubbo",
+				},
+				HostSuffix:       ".dubbo",
+				RegistryRootNode: "/dubbo",
+			}),
+		},
+		{
+			name: "gateway_mode_generic_dubbo",
+			data: []testData{
+				{
+					in:     "./testdata/gateway_mode_generic_dubbo.yaml",
+					expect: "./testdata/gateway_mode_generic_dubbo.expected.yaml",
+				},
+			},
+			s: newSource(&bootstrap.ZookeeperSourceArgs{
+				SourceArgs: bootstrap.SourceArgs{
+					GenericProtocol:       true,
+					SvcProtocol:           "DUBBO",
+					SvcPort:               80,
+					InstancePortAsSvcPort: false,
+					ResourceNs:            "dubbo",
+					DefaultServiceNs:      "dubbo",
+				},
+				HostSuffix:       ".dubbo",
+				RegistryRootNode: "/dubbo",
+			}),
+		},
+		// TODO: add test cases for:
+		// - instance filter
+		// - instance meta modifier
+		// - method lb checker
+		// - ...
+	}
+
+	initTest := func(s *Source) {
+		mockClient.Reset()
+		s.Con = mockClient
+		assertHandler.Reset()
+		s.Dispatch(assertHandler)
+	}
+
+	for _, tt := range args {
+		initTest(tt.s)
+		t.Run(tt.name, func(t *testing.T) {
+			for _, d := range tt.data {
+				if d.clientErr != nil {
+					assert.Error(t, tt.s.updateServiceInfo())
+					continue
+				}
+				if d.in != "" {
+					assert.NoError(t, mockClient.LoadData(d.in))
+				}
+				if d.expect != "" {
+					assertHandler.Reset()
+					assert.NoError(t, assertHandler.LoadExpected(d.expect))
+				}
+				assert.NoError(t, tt.s.updateServiceInfo())
+				if tt.s.args.EnableDubboSidecar {
+					tt.s.refreshSidecar(false)
+				}
+				if tt.s.seMergePortMocker != nil {
+					tt.s.seMergePortMocker.Refresh()
+				}
+				assertHandler.DumpGot()
+				assertHandler.Assert(t)
 			}
 		})
 	}

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/zookeeper/testdata/gateway_mode_generic_dubbo.expected.yaml
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/zookeeper/testdata/gateway_mode_generic_dubbo.expected.yaml
@@ -1,0 +1,149 @@
+---
+kind: ServiceEntry
+apiVersion: networking.istio.io/v1alpha3
+metadata:
+  name: com.example.service.ServiceA:g:0.0.1
+  namespace: dubbo
+  labels:
+    path: com.example.service.ServiceA
+    registry: zookeeper
+  annotations: {}
+spec:
+  hosts:
+    - 'com.example.service.ServiceA:g:0.0.1.dubbo'
+  ports:
+    - number: 80
+      protocol: GENERIC
+      name: generic-dubbo-80
+  resolution: STATIC
+  endpoints:
+    - address: 10.0.0.1
+      ports:
+        generic-dubbo-80: 20880
+      labels:
+        application: service-a
+        group: g
+        interface: com.example.service.ServiceA
+        side: provider
+        version: 0.0.1
+---
+kind: ServiceEntry
+apiVersion: networking.istio.io/v1alpha3
+metadata:
+  name: com.example.service.ServiceA:g:0.0.2
+  namespace: dubbo
+  labels:
+    path: com.example.service.ServiceA
+    registry: zookeeper
+  annotations: {}
+spec:
+  hosts:
+    - 'com.example.service.ServiceA:g:0.0.2.dubbo'
+  ports:
+    - number: 80
+      protocol: GENERIC
+      name: generic-dubbo-80
+  resolution: STATIC
+  endpoints:
+    - address: 10.0.0.2
+      ports:
+        generic-dubbo-80: 20880
+      labels:
+        application: service-a
+        group: g
+        interface: com.example.service.ServiceA
+        side: provider
+        version: 0.0.2
+    - address: 10.0.0.3
+      ports:
+        generic-dubbo-80: 20880
+      labels:
+        application: service-a
+        group: g
+        interface: com.example.service.ServiceA
+        side: provider
+        version: 0.0.2
+---
+kind: ServiceEntry
+apiVersion: networking.istio.io/v1alpha3
+metadata:
+  name: com.example.service.ServiceB:g:0.0.1
+  namespace: dubbo
+  labels:
+    path: com.example.service.ServiceB
+    registry: zookeeper
+  annotations: {}
+spec:
+  hosts:
+    - 'com.example.service.ServiceB:g:0.0.1.dubbo'
+  ports:
+    - number: 80
+      protocol: GENERIC
+      name: generic-dubbo-80
+  resolution: STATIC
+  endpoints:
+    - address: 10.0.1.1
+      ports:
+        generic-dubbo-80: 20881
+      labels:
+        application: service-b
+        group: g
+        interface: com.example.service.ServiceB
+        side: provider
+        version: 0.0.1
+---
+kind: ServiceEntry
+apiVersion: networking.istio.io/v1alpha3
+metadata:
+  name: com.example.service.ServiceB:g2:0.0.1
+  namespace: dubbo
+  labels:
+    path: com.example.service.ServiceB
+    registry: zookeeper
+  annotations: {}
+spec:
+  hosts:
+    - 'com.example.service.ServiceB:g2:0.0.1.dubbo'
+  ports:
+    - number: 80
+      protocol: GENERIC
+      name: generic-dubbo-80
+  resolution: STATIC
+  endpoints:
+    - address: 10.0.1.2
+      ports:
+        generic-dubbo-80: 20881
+      labels:
+        application: service-b
+        group: g2
+        interface: com.example.service.ServiceB
+        side: provider
+        version: 0.0.1
+---
+kind: ServiceEntry
+apiVersion: networking.istio.io/v1alpha3
+metadata:
+  name: com.example.service.ServiceC:g2:0.0.1
+  namespace: dubbo
+  labels:
+    path: com.example.service.ServiceC
+    registry: zookeeper
+  annotations: {}
+spec:
+  hosts:
+    - 'com.example.service.ServiceC:g2:0.0.1.dubbo'
+  ports:
+    - number: 80
+      protocol: GENERIC
+      name: generic-dubbo-80
+  resolution: STATIC
+  endpoints:
+    - address: 10.0.2.1
+      ports:
+        generic-dubbo-80: 20882
+      labels:
+        application: service-c
+        group: g2
+        interface: com.example.service.ServiceC
+        side: provider
+        version: 0.0.1

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/zookeeper/testdata/gateway_mode_generic_dubbo.yaml
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/zookeeper/testdata/gateway_mode_generic_dubbo.yaml
@@ -1,0 +1,41 @@
+fullPath: "/"
+children:
+  dubbo:
+    fullPath: "/dubbo"
+    children:
+      com.example.service.ServiceA:
+        fullPath: "/dubbo/com.example.service.ServiceA"
+        children:
+          providers:
+            fullPath: "/dubbo/com.example.service.ServiceA/providers"
+            children:
+              # dubbo://10.0.0.1:20880/com.example.service.ServiceA?application=service-a&group=g&interface=com.example.service.ServiceA&methods=sayHelllo&side=provider&version=0.0.1
+              dubbo%3A%2F%2F10.0.0.1%3A20880%2Fcom.example.service.ServiceA%3Fapplication%3Dservice-a%26group%3Dg%26interface%3Dcom.example.service.ServiceA%26methods%3DsayHelllo%26side%3Dprovider%26version%3D0.0.1:
+                fullPath: "/dubbo/com.example.service.ServiceA/providers/dubbo%3A%2F%2F10.0.0.1%3A20880%2Fcom.example.service.ServiceA%3Fapplication%3Dservice-a%26group%3Dg%26interface%3Dcom.example.service.ServiceA%26methods%3DsayHelllo%26side%3Dprovider%26version%3D0.0.1"
+              # dubbo://10.0.0.2:20880/com.example.service.ServiceA?application=service-a&group=g&interface=com.example.service.ServiceA&methods=sayHelllo&side=provider&version=0.0.2
+              dubbo%3A%2F%2F10.0.0.2%3A20880%2Fcom.example.service.ServiceA%3Fapplication%3Dservice-a%26group%3Dg%26interface%3Dcom.example.service.ServiceA%26methods%3DsayHelllo%26side%3Dprovider%26version%3D0.0.2:
+                fullPath: "/dubbo/com.example.service.ServiceA/providers/dubbo%3A%2F%2F10.0.0.2%3A20880%2Fcom.example.service.ServiceA%3Fapplication%3Dservice-a%26group%3Dg%26interface%3Dcom.example.service.ServiceA%26methods%3DsayHelllo%26side%3Dprovider%26version%3D0.0.2"
+              # dubbo://10.0.0.3:20880/com.example.service.ServiceA?application=service-a&group=g&interface=com.example.service.ServiceA&methods=sayHelllo&side=provider&version=0.0.2
+              dubbo%3A%2F%2F10.0.0.3%3A20880%2Fcom.example.service.ServiceA%3Fapplication%3Dservice-a%26group%3Dg%26interface%3Dcom.example.service.ServiceA%26methods%3DsayHelllo%26side%3Dprovider%26version%3D0.0.2:
+                fullPath: "/dubbo/com.example.service.ServiceA/providers/dubbo%3A%2F%2F10.0.0.3%3A20880%2Fcom.example.service.ServiceA%3Fapplication%3Dservice-a%26group%3Dg%26interface%3Dcom.example.service.ServiceA%26methods%3DsayHelllo%26side%3Dprovider%26version%3D0.0.2"
+      com.example.service.ServiceB:
+        fullPath: "/dubbo/com.example.service.ServiceB"
+        children:
+          providers:
+            fullPath: "/dubbo/com.example.service.ServiceB/providers"
+            children:
+              # dubbo://10.0.1.1:20881/com.example.service.ServiceB?application=service-b&group=g&interface=com.example.service.ServiceB&methods=sayHelllo&side=provider&version=0.0.1
+              dubbo%3A%2F%2F10.0.1.1%3A20881%2Fcom.example.service.ServiceB%3Fapplication%3Dservice-b%26group%3Dg%26interface%3Dcom.example.service.ServiceB%26methods%3DsayHelllo%26side%3Dprovider%26version%3D0.0.1:
+                fullPath: "/dubbo/com.example.service.ServiceA/providers/dubbo%3A%2F%2F10.0.1.1%3A20881%2Fcom.example.service.ServiceB%3Fapplication%3Dservice-b%26group%3Dg%26interface%3Dcom.example.service.ServiceB%26methods%3DsayHelllo%26side%3Dprovider%26version%3D0.0.1"
+              # dubbo://10.0.1.2:20881/com.example.service.ServiceB?application=service-b&group=g2&interface=com.example.service.ServiceB&methods=sayHelllo&side=provider&version=0.0.1
+              dubbo%3A%2F%2F10.0.1.2%3A20881%2Fcom.example.service.ServiceB%3Fapplication%3Dservice-b%26group%3Dg2%26interface%3Dcom.example.service.ServiceB%26methods%3DsayHelllo%26side%3Dprovider%26version%3D0.0.1:
+                fullPath: "/dubbo/com.example.service.ServiceA/providers/dubbo%3A%2F%2F10.0.1.2%3A20881%2Fcom.example.service.ServiceB%3Fapplication%3Dservice-b%26group%3Dg2%26interface%3Dcom.example.service.ServiceB%26methods%3DsayHelllo%26side%3Dprovider%26version%3D0.0.1"
+      com.example.service.ServiceC:
+        fullPath: "/dubbo/com.example.service.ServiceC"
+        children:
+          providers:
+            fullPath: "/dubbo/com.example.service.ServiceC/providers"
+            children:
+              # dubbo://10.0.2.1:20882/com.example.service.ServiceC?application=service-c&group=g2&interface=com.example.service.ServiceC&methods=sayHelllo&side=provider&version=0.0.1
+              dubbo%3A%2F%2F10.0.2.1%3A20882%2Fcom.example.service.ServiceC%3Fapplication%3Dservice-c%26group%3Dg2%26interface%3Dcom.example.service.ServiceC%26methods%3DsayHelllo%26side%3Dprovider%26version%3D0.0.1:
+                fullPath: "/dubbo/com.example.service.ServiceA/providers/dubbo%3A%2F%2F10.0.2.1%3A20882%2Fcom.example.service.ServiceC%3Fapplication%3Dservice-c%26group%3Dg2%26interface%3Dcom.example.service.ServiceC%26methods%3DsayHelllo%26side%3Dprovider%26version%3D0.0.1"

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/zookeeper/testdata/legacy_gateway_mode.expected.yaml
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/zookeeper/testdata/legacy_gateway_mode.expected.yaml
@@ -1,0 +1,149 @@
+---
+kind: ServiceEntry
+apiVersion: networking.istio.io/v1alpha3
+metadata:
+  name: com.example.service.ServiceA:g:0.0.1
+  namespace: dubbo
+  labels:
+    path: com.example.service.ServiceA
+    registry: zookeeper
+  annotations: {}
+spec:
+  hosts:
+    - 'com.example.service.ServiceA:g:0.0.1.dubbo'
+  ports:
+    - number: 80
+      protocol: HTTP
+      name: http-80
+  resolution: STATIC
+  endpoints:
+    - address: 10.0.0.1
+      ports:
+        http-80: 20880
+      labels:
+        application: service-a
+        group: g
+        interface: com.example.service.ServiceA
+        side: provider
+        version: 0.0.1
+---
+kind: ServiceEntry
+apiVersion: networking.istio.io/v1alpha3
+metadata:
+  name: com.example.service.ServiceA:g:0.0.2
+  namespace: dubbo
+  labels:
+    path: com.example.service.ServiceA
+    registry: zookeeper
+  annotations: {}
+spec:
+  hosts:
+    - 'com.example.service.ServiceA:g:0.0.2.dubbo'
+  ports:
+    - number: 80
+      protocol: HTTP
+      name: http-80
+  resolution: STATIC
+  endpoints:
+    - address: 10.0.0.2
+      ports:
+        http-80: 20880
+      labels:
+        application: service-a
+        group: g
+        interface: com.example.service.ServiceA
+        side: provider
+        version: 0.0.2
+    - address: 10.0.0.3
+      ports:
+        http-80: 20880
+      labels:
+        application: service-a
+        group: g
+        interface: com.example.service.ServiceA
+        side: provider
+        version: 0.0.2
+---
+kind: ServiceEntry
+apiVersion: networking.istio.io/v1alpha3
+metadata:
+  name: com.example.service.ServiceB:g:0.0.1
+  namespace: dubbo
+  labels:
+    path: com.example.service.ServiceB
+    registry: zookeeper
+  annotations: {}
+spec:
+  hosts:
+    - 'com.example.service.ServiceB:g:0.0.1.dubbo'
+  ports:
+    - number: 80
+      protocol: HTTP
+      name: http-80
+  resolution: STATIC
+  endpoints:
+    - address: 10.0.1.1
+      ports:
+        http-80: 20881
+      labels:
+        application: service-b
+        group: g
+        interface: com.example.service.ServiceB
+        side: provider
+        version: 0.0.1
+---
+kind: ServiceEntry
+apiVersion: networking.istio.io/v1alpha3
+metadata:
+  name: com.example.service.ServiceB:g2:0.0.1
+  namespace: dubbo
+  labels:
+    path: com.example.service.ServiceB
+    registry: zookeeper
+  annotations: {}
+spec:
+  hosts:
+    - 'com.example.service.ServiceB:g2:0.0.1.dubbo'
+  ports:
+    - number: 80
+      protocol: HTTP
+      name: http-80
+  resolution: STATIC
+  endpoints:
+    - address: 10.0.1.2
+      ports:
+        http-80: 20881
+      labels:
+        application: service-b
+        group: g2
+        interface: com.example.service.ServiceB
+        side: provider
+        version: 0.0.1
+---
+kind: ServiceEntry
+apiVersion: networking.istio.io/v1alpha3
+metadata:
+  name: com.example.service.ServiceC:g2:0.0.1
+  namespace: dubbo
+  labels:
+    path: com.example.service.ServiceC
+    registry: zookeeper
+  annotations: {}
+spec:
+  hosts:
+    - 'com.example.service.ServiceC:g2:0.0.1.dubbo'
+  ports:
+    - number: 80
+      protocol: HTTP
+      name: http-80
+  resolution: STATIC
+  endpoints:
+    - address: 10.0.2.1
+      ports:
+        http-80: 20882
+      labels:
+        application: service-c
+        group: g2
+        interface: com.example.service.ServiceC
+        side: provider
+        version: 0.0.1

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/zookeeper/testdata/legacy_gateway_mode.yaml
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/zookeeper/testdata/legacy_gateway_mode.yaml
@@ -1,0 +1,41 @@
+fullPath: "/"
+children:
+  dubbo:
+    fullPath: "/dubbo"
+    children:
+      com.example.service.ServiceA:
+        fullPath: "/dubbo/com.example.service.ServiceA"
+        children:
+          providers:
+            fullPath: "/dubbo/com.example.service.ServiceA/providers"
+            children:
+              # dubbo://10.0.0.1:20880/com.example.service.ServiceA?application=service-a&group=g&interface=com.example.service.ServiceA&methods=sayHelllo&side=provider&version=0.0.1
+              dubbo%3A%2F%2F10.0.0.1%3A20880%2Fcom.example.service.ServiceA%3Fapplication%3Dservice-a%26group%3Dg%26interface%3Dcom.example.service.ServiceA%26methods%3DsayHelllo%26side%3Dprovider%26version%3D0.0.1:
+                fullPath: "/dubbo/com.example.service.ServiceA/providers/dubbo%3A%2F%2F10.0.0.1%3A20880%2Fcom.example.service.ServiceA%3Fapplication%3Dservice-a%26group%3Dg%26interface%3Dcom.example.service.ServiceA%26methods%3DsayHelllo%26side%3Dprovider%26version%3D0.0.1"
+              # dubbo://10.0.0.2:20880/com.example.service.ServiceA?application=service-a&group=g&interface=com.example.service.ServiceA&methods=sayHelllo&side=provider&version=0.0.2
+              dubbo%3A%2F%2F10.0.0.2%3A20880%2Fcom.example.service.ServiceA%3Fapplication%3Dservice-a%26group%3Dg%26interface%3Dcom.example.service.ServiceA%26methods%3DsayHelllo%26side%3Dprovider%26version%3D0.0.2:
+                fullPath: "/dubbo/com.example.service.ServiceA/providers/dubbo%3A%2F%2F10.0.0.2%3A20880%2Fcom.example.service.ServiceA%3Fapplication%3Dservice-a%26group%3Dg%26interface%3Dcom.example.service.ServiceA%26methods%3DsayHelllo%26side%3Dprovider%26version%3D0.0.2"
+              # dubbo://10.0.0.3:20880/com.example.service.ServiceA?application=service-a&group=g&interface=com.example.service.ServiceA&methods=sayHelllo&side=provider&version=0.0.2
+              dubbo%3A%2F%2F10.0.0.3%3A20880%2Fcom.example.service.ServiceA%3Fapplication%3Dservice-a%26group%3Dg%26interface%3Dcom.example.service.ServiceA%26methods%3DsayHelllo%26side%3Dprovider%26version%3D0.0.2:
+                fullPath: "/dubbo/com.example.service.ServiceA/providers/dubbo%3A%2F%2F10.0.0.3%3A20880%2Fcom.example.service.ServiceA%3Fapplication%3Dservice-a%26group%3Dg%26interface%3Dcom.example.service.ServiceA%26methods%3DsayHelllo%26side%3Dprovider%26version%3D0.0.2"
+      com.example.service.ServiceB:
+        fullPath: "/dubbo/com.example.service.ServiceB"
+        children:
+          providers:
+            fullPath: "/dubbo/com.example.service.ServiceB/providers"
+            children:
+              # dubbo://10.0.1.1:20881/com.example.service.ServiceB?application=service-b&group=g&interface=com.example.service.ServiceB&methods=sayHelllo&side=provider&version=0.0.1
+              dubbo%3A%2F%2F10.0.1.1%3A20881%2Fcom.example.service.ServiceB%3Fapplication%3Dservice-b%26group%3Dg%26interface%3Dcom.example.service.ServiceB%26methods%3DsayHelllo%26side%3Dprovider%26version%3D0.0.1:
+                fullPath: "/dubbo/com.example.service.ServiceA/providers/dubbo%3A%2F%2F10.0.1.1%3A20881%2Fcom.example.service.ServiceB%3Fapplication%3Dservice-b%26group%3Dg%26interface%3Dcom.example.service.ServiceB%26methods%3DsayHelllo%26side%3Dprovider%26version%3D0.0.1"
+              # dubbo://10.0.1.2:20881/com.example.service.ServiceB?application=service-b&group=g2&interface=com.example.service.ServiceB&methods=sayHelllo&side=provider&version=0.0.1
+              dubbo%3A%2F%2F10.0.1.2%3A20881%2Fcom.example.service.ServiceB%3Fapplication%3Dservice-b%26group%3Dg2%26interface%3Dcom.example.service.ServiceB%26methods%3DsayHelllo%26side%3Dprovider%26version%3D0.0.1:
+                fullPath: "/dubbo/com.example.service.ServiceA/providers/dubbo%3A%2F%2F10.0.1.2%3A20881%2Fcom.example.service.ServiceB%3Fapplication%3Dservice-b%26group%3Dg2%26interface%3Dcom.example.service.ServiceB%26methods%3DsayHelllo%26side%3Dprovider%26version%3D0.0.1"
+      com.example.service.ServiceC:
+        fullPath: "/dubbo/com.example.service.ServiceC"
+        children:
+          providers:
+            fullPath: "/dubbo/com.example.service.ServiceC/providers"
+            children:
+              # dubbo://10.0.2.1:20882/com.example.service.ServiceC?application=service-c&group=g2&interface=com.example.service.ServiceC&methods=sayHelllo&side=provider&version=0.0.1
+              dubbo%3A%2F%2F10.0.2.1%3A20882%2Fcom.example.service.ServiceC%3Fapplication%3Dservice-c%26group%3Dg2%26interface%3Dcom.example.service.ServiceC%26methods%3DsayHelllo%26side%3Dprovider%26version%3D0.0.1:
+                fullPath: "/dubbo/com.example.service.ServiceA/providers/dubbo%3A%2F%2F10.0.2.1%3A20882%2Fcom.example.service.ServiceC%3Fapplication%3Dservice-c%26group%3Dg2%26interface%3Dcom.example.service.ServiceC%26methods%3DsayHelllo%26side%3Dprovider%26version%3D0.0.1"

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/zookeeper/testdata/simple.expected.yaml
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/zookeeper/testdata/simple.expected.yaml
@@ -1,0 +1,149 @@
+---
+kind: ServiceEntry
+apiVersion: networking.istio.io/v1alpha3
+metadata:
+  name: com.example.service.ServiceA:g:0.0.1
+  namespace: dubbo
+  labels:
+    path: com.example.service.ServiceA
+    registry: zookeeper
+  annotations: {}
+spec:
+  hosts:
+    - 'com.example.service.ServiceA:g:0.0.1'
+  ports:
+    - number: 20880
+      protocol: DUBBO
+      name: dubbo-20880
+  resolution: STATIC
+  endpoints:
+    - address: 10.0.0.1
+      ports:
+        dubbo-20880: 20880
+      labels:
+        application: service-a
+        group: g
+        interface: com.example.service.ServiceA
+        side: provider
+        version: 0.0.1
+---
+kind: ServiceEntry
+apiVersion: networking.istio.io/v1alpha3
+metadata:
+  name: com.example.service.ServiceA:g:0.0.2
+  namespace: dubbo
+  labels:
+    path: com.example.service.ServiceA
+    registry: zookeeper
+  annotations: {}
+spec:
+  hosts:
+    - 'com.example.service.ServiceA:g:0.0.2'
+  ports:
+    - number: 20880
+      protocol: DUBBO
+      name: dubbo-20880
+  resolution: STATIC
+  endpoints:
+    - address: 10.0.0.2
+      ports:
+        dubbo-20880: 20880
+      labels:
+        application: service-a
+        group: g
+        interface: com.example.service.ServiceA
+        side: provider
+        version: 0.0.2
+    - address: 10.0.0.3
+      ports:
+        dubbo-20880: 20880
+      labels:
+        application: service-a
+        group: g
+        interface: com.example.service.ServiceA
+        side: provider
+        version: 0.0.2
+---
+kind: ServiceEntry
+apiVersion: networking.istio.io/v1alpha3
+metadata:
+  name: com.example.service.ServiceB:g:0.0.1
+  namespace: dubbo
+  labels:
+    path: com.example.service.ServiceB
+    registry: zookeeper
+  annotations: {}
+spec:
+  hosts:
+    - 'com.example.service.ServiceB:g:0.0.1'
+  ports:
+    - number: 20881
+      protocol: DUBBO
+      name: dubbo-20881
+  resolution: STATIC
+  endpoints:
+    - address: 10.0.1.1
+      ports:
+        dubbo-20881: 20881
+      labels:
+        application: service-b
+        group: g
+        interface: com.example.service.ServiceB
+        side: provider
+        version: 0.0.1
+---
+kind: ServiceEntry
+apiVersion: networking.istio.io/v1alpha3
+metadata:
+  name: com.example.service.ServiceB:g2:0.0.1
+  namespace: dubbo
+  labels:
+    path: com.example.service.ServiceB
+    registry: zookeeper
+  annotations: {}
+spec:
+  hosts:
+    - 'com.example.service.ServiceB:g2:0.0.1'
+  ports:
+    - number: 20881
+      protocol: DUBBO
+      name: dubbo-20881
+  resolution: STATIC
+  endpoints:
+    - address: 10.0.1.2
+      ports:
+        dubbo-20881: 20881
+      labels:
+        application: service-b
+        group: g2
+        interface: com.example.service.ServiceB
+        side: provider
+        version: 0.0.1
+---
+kind: ServiceEntry
+apiVersion: networking.istio.io/v1alpha3
+metadata:
+  name: com.example.service.ServiceC:g2:0.0.1
+  namespace: dubbo
+  labels:
+    path: com.example.service.ServiceC
+    registry: zookeeper
+  annotations: {}
+spec:
+  hosts:
+    - 'com.example.service.ServiceC:g2:0.0.1'
+  ports:
+    - number: 20882
+      protocol: DUBBO
+      name: dubbo-20882
+  resolution: STATIC
+  endpoints:
+    - address: 10.0.2.1
+      ports:
+        dubbo-20882: 20882
+      labels:
+        application: service-c
+        group: g2
+        interface: com.example.service.ServiceC
+        side: provider
+        version: 0.0.1

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/zookeeper/testdata/simple.yaml
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/zookeeper/testdata/simple.yaml
@@ -1,0 +1,72 @@
+# three dubbo interfaces:
+# 
+# - com.example.service.ServiceA
+# - com.example.service.ServiceB
+# - com.example.service.ServiceC
+# 
+# with the following call chain:
+# 
+#   ServiceA -> ServiceB -> ServiceC
+#
+fullPath: "/"
+children:
+  dubbo:
+    fullPath: "/dubbo"
+    children:
+      com.example.service.ServiceA:
+        fullPath: "/dubbo/com.example.service.ServiceA"
+        children:
+          providers:
+            fullPath: "/dubbo/com.example.service.ServiceA/providers"
+            children:
+              # dubbo://10.0.0.1:20880/com.example.service.ServiceA?application=service-a&group=g&interface=com.example.service.ServiceA&methods=sayHelllo&side=provider&version=0.0.1
+              dubbo%3A%2F%2F10.0.0.1%3A20880%2Fcom.example.service.ServiceA%3Fapplication%3Dservice-a%26group%3Dg%26interface%3Dcom.example.service.ServiceA%26methods%3DsayHelllo%26side%3Dprovider%26version%3D0.0.1:
+                fullPath: "/dubbo/com.example.service.ServiceA/providers/dubbo%3A%2F%2F10.0.0.1%3A20880%2Fcom.example.service.ServiceA%3Fapplication%3Dservice-a%26group%3Dg%26interface%3Dcom.example.service.ServiceA%26methods%3DsayHelllo%26side%3Dprovider%26version%3D0.0.1"
+              # dubbo://10.0.0.2:20880/com.example.service.ServiceA?application=service-a&group=g&interface=com.example.service.ServiceA&methods=sayHelllo&side=provider&version=0.0.2
+              dubbo%3A%2F%2F10.0.0.2%3A20880%2Fcom.example.service.ServiceA%3Fapplication%3Dservice-a%26group%3Dg%26interface%3Dcom.example.service.ServiceA%26methods%3DsayHelllo%26side%3Dprovider%26version%3D0.0.2:
+                fullPath: "/dubbo/com.example.service.ServiceA/providers/dubbo%3A%2F%2F10.0.0.2%3A20880%2Fcom.example.service.ServiceA%3Fapplication%3Dservice-a%26group%3Dg%26interface%3Dcom.example.service.ServiceA%26methods%3DsayHelllo%26side%3Dprovider%26version%3D0.0.2"
+              # dubbo://10.0.0.3:20880/com.example.service.ServiceA?application=service-a&group=g&interface=com.example.service.ServiceA&methods=sayHelllo&side=provider&version=0.0.2
+              dubbo%3A%2F%2F10.0.0.3%3A20880%2Fcom.example.service.ServiceA%3Fapplication%3Dservice-a%26group%3Dg%26interface%3Dcom.example.service.ServiceA%26methods%3DsayHelllo%26side%3Dprovider%26version%3D0.0.2:
+                fullPath: "/dubbo/com.example.service.ServiceA/providers/dubbo%3A%2F%2F10.0.0.3%3A20880%2Fcom.example.service.ServiceA%3Fapplication%3Dservice-a%26group%3Dg%26interface%3Dcom.example.service.ServiceA%26methods%3DsayHelllo%26side%3Dprovider%26version%3D0.0.2"
+      com.example.service.ServiceB:
+        fullPath: "/dubbo/com.example.service.ServiceB"
+        children:
+          providers:
+            fullPath: "/dubbo/com.example.service.ServiceB/providers"
+            children:
+              # dubbo://10.0.1.1:20881/com.example.service.ServiceB?application=service-b&group=g&interface=com.example.service.ServiceB&methods=sayHelllo&side=provider&version=0.0.1
+              dubbo%3A%2F%2F10.0.1.1%3A20881%2Fcom.example.service.ServiceB%3Fapplication%3Dservice-b%26group%3Dg%26interface%3Dcom.example.service.ServiceB%26methods%3DsayHelllo%26side%3Dprovider%26version%3D0.0.1:
+                fullPath: "/dubbo/com.example.service.ServiceA/providers/dubbo%3A%2F%2F10.0.1.1%3A20881%2Fcom.example.service.ServiceB%3Fapplication%3Dservice-b%26group%3Dg%26interface%3Dcom.example.service.ServiceB%26methods%3DsayHelllo%26side%3Dprovider%26version%3D0.0.1"
+              # dubbo://10.0.1.2:20881/com.example.service.ServiceB?application=service-b&group=g2&interface=com.example.service.ServiceB&methods=sayHelllo&side=provider&version=0.0.1
+              dubbo%3A%2F%2F10.0.1.2%3A20881%2Fcom.example.service.ServiceB%3Fapplication%3Dservice-b%26group%3Dg2%26interface%3Dcom.example.service.ServiceB%26methods%3DsayHelllo%26side%3Dprovider%26version%3D0.0.1:
+                fullPath: "/dubbo/com.example.service.ServiceA/providers/dubbo%3A%2F%2F10.0.1.2%3A20881%2Fcom.example.service.ServiceB%3Fapplication%3Dservice-b%26group%3Dg2%26interface%3Dcom.example.service.ServiceB%26methods%3DsayHelllo%26side%3Dprovider%26version%3D0.0.1"
+          consumers:
+            fullPath: "/dubbo/com.example.service.ServiceB/consumers"
+            children:
+              # consumer://10.0.0.1/com.example.service.ServiceB?application=service-a&group=g2&interface=com.example.service.ServiceB&methods=sayHelllo&side=consumer&version=0.0.1
+              consumer%3A%2F%2F10.0.0.1%2Fcom.example.service.ServiceB%3Fapplication%3Dservice-a%26group%3Dg2%26interface%3Dcom.example.service.ServiceB%26methods%3DsayHelllo%26side%3Dconsumer%26version%3D0.0.1:
+                fullPath: "/dubbo/com.example.service.ServiceB/consumers/consumer%3A%2F%2F10.0.0.1%2Fcom.example.service.ServiceB%3Fapplication%3Dservice-a%26group%3Dg2%26interface%3Dcom.example.service.ServiceB%26methods%3DsayHelllo%26side%3Dconsumer%26version%3D0.0.1"
+              # consumer://10.0.0.2/com.example.service.ServiceB?application=service-a&group=g&interface=com.example.service.ServiceB&methods=sayHelllo&side=consumer&version=0.0.1
+              consumer%3A%2F%2F10.0.0.2%2Fcom.example.service.ServiceB%3Fapplication%3Dservice-a%26group%3Dg%26interface%3Dcom.example.service.ServiceB%26methods%3DsayHelllo%26side%3Dconsumer%26version%3D0.0.1:
+                fullPath: "/dubbo/com.example.service.ServiceB/consumers/consumer%3A%2F%2F10.0.0.2%2Fcom.example.service.ServiceB%3Fapplication%3Dservice-a%26group%3Dg%26interface%3Dcom.example.service.ServiceB%26methods%3DsayHelllo%26side%3Dconsumer%26version%3D0.0.1"
+              # consumer://10.0.0.3/com.example.service.ServiceB?application=service-a&group=g&interface=com.example.service.ServiceB&methods=sayHelllo&side=consumer&version=0.0.1
+              consumer%3A%2F%2F10.0.0.3%2Fcom.example.service.ServiceB%3Fapplication%3Dservice-a%26group%3Dg%26interface%3Dcom.example.service.ServiceB%26methods%3DsayHelllo%26side%3Dconsumer%26version%3D0.0.1:
+                fullPath: "/dubbo/com.example.service.ServiceB/consumers/consumer%3A%2F%2F10.0.0.3%2Fcom.example.service.ServiceB%3Fapplication%3Dservice-a%26group%3Dg%26interface%3Dcom.example.service.ServiceB%26methods%3DsayHelllo%26side%3Dconsumer%26version%3D0.0.1"
+      com.example.service.ServiceC:
+        fullPath: "/dubbo/com.example.service.ServiceC"
+        children:
+          providers:
+            fullPath: "/dubbo/com.example.service.ServiceC/providers"
+            children:
+              # dubbo://10.0.2.1:20882/com.example.service.ServiceC?application=service-c&group=g2&interface=com.example.service.ServiceC&methods=sayHelllo&side=provider&version=0.0.1
+              dubbo%3A%2F%2F10.0.2.1%3A20882%2Fcom.example.service.ServiceC%3Fapplication%3Dservice-c%26group%3Dg2%26interface%3Dcom.example.service.ServiceC%26methods%3DsayHelllo%26side%3Dprovider%26version%3D0.0.1:
+                fullPath: "/dubbo/com.example.service.ServiceA/providers/dubbo%3A%2F%2F10.0.2.1%3A20882%2Fcom.example.service.ServiceC%3Fapplication%3Dservice-c%26group%3Dg2%26interface%3Dcom.example.service.ServiceC%26methods%3DsayHelllo%26side%3Dprovider%26version%3D0.0.1"
+          consumers:
+            fullPath: "/dubbo/com.example.service.ServiceC/consumers"
+            children:
+              # consumer://10.0.1.1/com.example.service.ServiceC?application=service-b&group=g2&interface=com.example.service.ServiceC&methods=sayHelllo&side=consumer&version=0.0.1
+              consumer%3A%2F%2F10.0.1.1%2Fcom.example.service.ServiceC%3Fapplication%3Dservice-b%26group%3Dg2%26interface%3Dcom.example.service.ServiceC%26methods%3DsayHelllo%26side%3Dconsumer%26version%3D0.0.1:
+                fullPath: "/dubbo/com.example.service.ServiceC/consumers/consumer%3A%2F%2F10.0.1.1%2Fcom.example.service.ServiceC%3Fapplication%3Dservice-b%26group%3Dg2%26interface%3Dcom.example.service.ServiceC%26methods%3DsayHelllo%26side%3Dconsumer%26version%3D0.0.1"
+              # consumer://10.0.1.2/com.example.service.ServiceC?application=service-b&group=g2&interface=com.example.service.ServiceC&methods=sayHelllo&side=consumer&version=0.0.1
+              consumer%3A%2F%2F10.0.1.2%2Fcom.example.service.ServiceC%3Fapplication%3Dservice-b%26group%3Dg2%26interface%3Dcom.example.service.ServiceC%26methods%3DsayHelllo%26side%3Dconsumer%26version%3D0.0.1:
+                fullPath: "/dubbo/com.example.service.ServiceC/consumers/consumer%3A%2F%2F10.0.1.2%2Fcom.example.service.ServiceC%3Fapplication%3Dservice-b%26group%3Dg2%26interface%3Dcom.example.service.ServiceC%26methods%3DsayHelllo%26side%3Dconsumer%26version%3D0.0.1"

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/zookeeper/testdata/simple_scale_down_instance.expected.yaml
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/zookeeper/testdata/simple_scale_down_instance.expected.yaml
@@ -1,0 +1,46 @@
+---
+kind: ServiceEntry
+apiVersion: networking.istio.io/v1alpha3
+metadata:
+  name: com.example.service.ServiceA:g:0.0.2
+  namespace: dubbo
+  labels:
+    path: com.example.service.ServiceA
+    registry: zookeeper
+  annotations: {}
+spec:
+  hosts:
+    - 'com.example.service.ServiceA:g:0.0.2'
+  ports:
+    - number: 20880
+      protocol: DUBBO
+      name: dubbo-20880
+  resolution: STATIC
+  endpoints:
+    - address: 10.0.0.2
+      ports:
+        dubbo-20880: 20880
+      labels:
+        application: service-a
+        group: g
+        interface: com.example.service.ServiceA
+        side: provider
+        version: 0.0.2
+---
+kind: ServiceEntry
+apiVersion: networking.istio.io/v1alpha3
+metadata:
+  name: com.example.service.ServiceB:g2:0.0.1
+  namespace: dubbo
+  labels:
+    path: com.example.service.ServiceB
+    registry: zookeeper
+  annotations: {}
+spec:
+  hosts:
+    - 'com.example.service.ServiceB:g2:0.0.1'
+  ports:
+    - number: 20881
+      protocol: DUBBO
+      name: dubbo-20881
+  resolution: STATIC

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/zookeeper/testdata/simple_scale_down_instance.yaml
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/zookeeper/testdata/simple_scale_down_instance.yaml
@@ -1,0 +1,73 @@
+# Covers both `n to 0` and `n to 1` scenarios:
+# - scale version=0.0.2 of service-a from 2 to 1
+# - scale group=g2 of service-b from 1 to 0
+# 
+# The event.Handler should only receive changed service entries,
+# which means that the expected should only contain the following entries:
+# - com.example.service.ServiceA:g:0.0.2
+# - com.example.service.ServiceB:g2:0.0.1
+
+fullPath: "/"
+children:
+  dubbo:
+    fullPath: "/dubbo"
+    children:
+      com.example.service.ServiceA:
+        fullPath: "/dubbo/com.example.service.ServiceA"
+        children:
+          providers:
+            fullPath: "/dubbo/com.example.service.ServiceA/providers"
+            children:
+              # dubbo://10.0.0.1:20880/com.example.service.ServiceA?application=service-a&group=g&interface=com.example.service.ServiceA&methods=sayHelllo&side=provider&version=0.0.1
+              dubbo%3A%2F%2F10.0.0.1%3A20880%2Fcom.example.service.ServiceA%3Fapplication%3Dservice-a%26group%3Dg%26interface%3Dcom.example.service.ServiceA%26methods%3DsayHelllo%26side%3Dprovider%26version%3D0.0.1:
+                fullPath: "/dubbo/com.example.service.ServiceA/providers/dubbo%3A%2F%2F10.0.0.1%3A20880%2Fcom.example.service.ServiceA%3Fapplication%3Dservice-a%26group%3Dg%26interface%3Dcom.example.service.ServiceA%26methods%3DsayHelllo%26side%3Dprovider%26version%3D0.0.1"
+              # dubbo://10.0.0.2:20880/com.example.service.ServiceA?application=service-a&group=g&interface=com.example.service.ServiceA&methods=sayHelllo&side=provider&version=0.0.2
+              dubbo%3A%2F%2F10.0.0.2%3A20880%2Fcom.example.service.ServiceA%3Fapplication%3Dservice-a%26group%3Dg%26interface%3Dcom.example.service.ServiceA%26methods%3DsayHelllo%26side%3Dprovider%26version%3D0.0.2:
+                fullPath: "/dubbo/com.example.service.ServiceA/providers/dubbo%3A%2F%2F10.0.0.2%3A20880%2Fcom.example.service.ServiceA%3Fapplication%3Dservice-a%26group%3Dg%26interface%3Dcom.example.service.ServiceA%26methods%3DsayHelllo%26side%3Dprovider%26version%3D0.0.2"
+              # n -> 1
+              # # dubbo://10.0.0.3:20880/com.example.service.ServiceA?application=service-a&group=g&interface=com.example.service.ServiceA&methods=sayHelllo&side=provider&version=0.0.2
+              # dubbo%3A%2F%2F10.0.0.3%3A20880%2Fcom.example.service.ServiceA%3Fapplication%3Dservice-a%26group%3Dg%26interface%3Dcom.example.service.ServiceA%26methods%3DsayHelllo%26side%3Dprovider%26version%3D0.0.2:
+              #   fullPath: "/dubbo/com.example.service.ServiceA/providers/dubbo%3A%2F%2F10.0.0.3%3A20880%2Fcom.example.service.ServiceA%3Fapplication%3Dservice-a%26group%3Dg%26interface%3Dcom.example.service.ServiceA%26methods%3DsayHelllo%26side%3Dprovider%26version%3D0.0.2"
+      com.example.service.ServiceB:
+        fullPath: "/dubbo/com.example.service.ServiceB"
+        children:
+          providers:
+            fullPath: "/dubbo/com.example.service.ServiceB/providers"
+            children:
+              # dubbo://10.0.1.1:20881/com.example.service.ServiceB?application=service-b&group=g&interface=com.example.service.ServiceB&methods=sayHelllo&side=provider&version=0.0.1
+              dubbo%3A%2F%2F10.0.1.1%3A20881%2Fcom.example.service.ServiceB%3Fapplication%3Dservice-b%26group%3Dg%26interface%3Dcom.example.service.ServiceB%26methods%3DsayHelllo%26side%3Dprovider%26version%3D0.0.1:
+                fullPath: "/dubbo/com.example.service.ServiceA/providers/dubbo%3A%2F%2F10.0.1.1%3A20881%2Fcom.example.service.ServiceB%3Fapplication%3Dservice-b%26group%3Dg%26interface%3Dcom.example.service.ServiceB%26methods%3DsayHelllo%26side%3Dprovider%26version%3D0.0.1"
+              # n -> 0  
+              # # dubbo://10.0.1.2:20881/com.example.service.ServiceB?application=service-b&group=g2&interface=com.example.service.ServiceB&methods=sayHelllo&side=provider&version=0.0.1
+              # dubbo%3A%2F%2F10.0.1.2%3A20881%2Fcom.example.service.ServiceB%3Fapplication%3Dservice-b%26group%3Dg2%26interface%3Dcom.example.service.ServiceB%26methods%3DsayHelllo%26side%3Dprovider%26version%3D0.0.1:
+              #   fullPath: "/dubbo/com.example.service.ServiceA/providers/dubbo%3A%2F%2F10.0.1.2%3A20881%2Fcom.example.service.ServiceB%3Fapplication%3Dservice-b%26group%3Dg2%26interface%3Dcom.example.service.ServiceB%26methods%3DsayHelllo%26side%3Dprovider%26version%3D0.0.1"
+          consumers:
+            fullPath: "/dubbo/com.example.service.ServiceB/consumers"
+            children:
+              # consumer://10.0.0.1/com.example.service.ServiceB?application=service-a&group=g2&interface=com.example.service.ServiceB&methods=sayHelllo&side=consumer&version=0.0.1
+              consumer%3A%2F%2F10.0.0.1%2Fcom.example.service.ServiceB%3Fapplication%3Dservice-a%26group%3Dg2%26interface%3Dcom.example.service.ServiceB%26methods%3DsayHelllo%26side%3Dconsumer%26version%3D0.0.1:
+                fullPath: "/dubbo/com.example.service.ServiceB/consumers/consumer%3A%2F%2F10.0.0.1%2Fcom.example.service.ServiceB%3Fapplication%3Dservice-a%26group%3Dg2%26interface%3Dcom.example.service.ServiceB%26methods%3DsayHelllo%26side%3Dconsumer%26version%3D0.0.1"
+              # consumer://10.0.0.2/com.example.service.ServiceB?application=service-a&group=g&interface=com.example.service.ServiceB&methods=sayHelllo&side=consumer&version=0.0.1
+              consumer%3A%2F%2F10.0.0.2%2Fcom.example.service.ServiceB%3Fapplication%3Dservice-a%26group%3Dg%26interface%3Dcom.example.service.ServiceB%26methods%3DsayHelllo%26side%3Dconsumer%26version%3D0.0.1:
+                fullPath: "/dubbo/com.example.service.ServiceB/consumers/consumer%3A%2F%2F10.0.0.2%2Fcom.example.service.ServiceB%3Fapplication%3Dservice-a%26group%3Dg%26interface%3Dcom.example.service.ServiceB%26methods%3DsayHelllo%26side%3Dconsumer%26version%3D0.0.1"
+              # consumer://10.0.0.3/com.example.service.ServiceB?application=service-a&group=g&interface=com.example.service.ServiceB&methods=sayHelllo&side=consumer&version=0.0.1
+              consumer%3A%2F%2F10.0.0.3%2Fcom.example.service.ServiceB%3Fapplication%3Dservice-a%26group%3Dg%26interface%3Dcom.example.service.ServiceB%26methods%3DsayHelllo%26side%3Dconsumer%26version%3D0.0.1:
+                fullPath: "/dubbo/com.example.service.ServiceB/consumers/consumer%3A%2F%2F10.0.0.3%2Fcom.example.service.ServiceB%3Fapplication%3Dservice-a%26group%3Dg%26interface%3Dcom.example.service.ServiceB%26methods%3DsayHelllo%26side%3Dconsumer%26version%3D0.0.1"
+      com.example.service.ServiceC:
+        fullPath: "/dubbo/com.example.service.ServiceC"
+        children:
+          providers:
+            fullPath: "/dubbo/com.example.service.ServiceC/providers"
+            children:
+              # dubbo://10.0.2.1:20882/com.example.service.ServiceC?application=service-c&group=g2&interface=com.example.service.ServiceC&methods=sayHelllo&side=provider&version=0.0.1
+              dubbo%3A%2F%2F10.0.2.1%3A20882%2Fcom.example.service.ServiceC%3Fapplication%3Dservice-c%26group%3Dg2%26interface%3Dcom.example.service.ServiceC%26methods%3DsayHelllo%26side%3Dprovider%26version%3D0.0.1:
+                fullPath: "/dubbo/com.example.service.ServiceA/providers/dubbo%3A%2F%2F10.0.2.1%3A20882%2Fcom.example.service.ServiceC%3Fapplication%3Dservice-c%26group%3Dg2%26interface%3Dcom.example.service.ServiceC%26methods%3DsayHelllo%26side%3Dprovider%26version%3D0.0.1"
+          consumers:
+            fullPath: "/dubbo/com.example.service.ServiceC/consumers"
+            children:
+              # consumer://10.0.1.1/com.example.service.ServiceC?application=service-b&group=g2&interface=com.example.service.ServiceC&methods=sayHelllo&side=consumer&version=0.0.1
+              consumer%3A%2F%2F10.0.1.1%2Fcom.example.service.ServiceC%3Fapplication%3Dservice-b%26group%3Dg2%26interface%3Dcom.example.service.ServiceC%26methods%3DsayHelllo%26side%3Dconsumer%26version%3D0.0.1:
+                fullPath: "/dubbo/com.example.service.ServiceC/consumers/consumer%3A%2F%2F10.0.1.1%2Fcom.example.service.ServiceC%3Fapplication%3Dservice-b%26group%3Dg2%26interface%3Dcom.example.service.ServiceC%26methods%3DsayHelllo%26side%3Dconsumer%26version%3D0.0.1"
+              # consumer://10.0.1.2/com.example.service.ServiceC?application=service-b&group=g2&interface=com.example.service.ServiceC&methods=sayHelllo&side=consumer&version=0.0.1
+              consumer%3A%2F%2F10.0.1.2%2Fcom.example.service.ServiceC%3Fapplication%3Dservice-b%26group%3Dg2%26interface%3Dcom.example.service.ServiceC%26methods%3DsayHelllo%26side%3Dconsumer%26version%3D0.0.1:
+                fullPath: "/dubbo/com.example.service.ServiceC/consumers/consumer%3A%2F%2F10.0.1.2%2Fcom.example.service.ServiceC%3Fapplication%3Dservice-b%26group%3Dg2%26interface%3Dcom.example.service.ServiceC%26methods%3DsayHelllo%26side%3Dconsumer%26version%3D0.0.1"

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/zookeeper/testdata/simple_se_merge_port_mocker.expected.yaml
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/zookeeper/testdata/simple_se_merge_port_mocker.expected.yaml
@@ -1,0 +1,173 @@
+---
+kind: ServiceEntry
+apiVersion: networking.istio.io/v1alpha3
+metadata:
+  name: com.example.service.ServiceA:g:0.0.1
+  namespace: dubbo
+  labels:
+    path: com.example.service.ServiceA
+    registry: zookeeper
+  annotations: {}
+spec:
+  hosts:
+    - 'com.example.service.ServiceA:g:0.0.1'
+  ports:
+    - number: 20880
+      protocol: DUBBO
+      name: dubbo-20880
+  resolution: STATIC
+  endpoints:
+    - address: 10.0.0.1
+      ports:
+        dubbo-20880: 20880
+      labels:
+        application: service-a
+        group: g
+        interface: com.example.service.ServiceA
+        side: provider
+        version: 0.0.1
+---
+kind: ServiceEntry
+apiVersion: networking.istio.io/v1alpha3
+metadata:
+  name: com.example.service.ServiceA:g:0.0.2
+  namespace: dubbo
+  labels:
+    path: com.example.service.ServiceA
+    registry: zookeeper
+  annotations: {}
+spec:
+  hosts:
+    - 'com.example.service.ServiceA:g:0.0.2'
+  ports:
+    - number: 20880
+      protocol: DUBBO
+      name: dubbo-20880
+  resolution: STATIC
+  endpoints:
+    - address: 10.0.0.2
+      ports:
+        dubbo-20880: 20880
+      labels:
+        application: service-a
+        group: g
+        interface: com.example.service.ServiceA
+        side: provider
+        version: 0.0.2
+    - address: 10.0.0.3
+      ports:
+        dubbo-20880: 20880
+      labels:
+        application: service-a
+        group: g
+        interface: com.example.service.ServiceA
+        side: provider
+        version: 0.0.2
+---
+kind: ServiceEntry
+apiVersion: networking.istio.io/v1alpha3
+metadata:
+  name: com.example.service.ServiceB:g:0.0.1
+  namespace: dubbo
+  labels:
+    path: com.example.service.ServiceB
+    registry: zookeeper
+  annotations: {}
+spec:
+  hosts:
+    - 'com.example.service.ServiceB:g:0.0.1'
+  ports:
+    - number: 20881
+      protocol: DUBBO
+      name: dubbo-20881
+  resolution: STATIC
+  endpoints:
+    - address: 10.0.1.1
+      ports:
+        dubbo-20881: 20881
+      labels:
+        application: service-b
+        group: g
+        interface: com.example.service.ServiceB
+        side: provider
+        version: 0.0.1
+---
+kind: ServiceEntry
+apiVersion: networking.istio.io/v1alpha3
+metadata:
+  name: com.example.service.ServiceB:g2:0.0.1
+  namespace: dubbo
+  labels:
+    path: com.example.service.ServiceB
+    registry: zookeeper
+  annotations: {}
+spec:
+  hosts:
+    - 'com.example.service.ServiceB:g2:0.0.1'
+  ports:
+    - number: 20881
+      protocol: DUBBO
+      name: dubbo-20881
+  resolution: STATIC
+  endpoints:
+    - address: 10.0.1.2
+      ports:
+        dubbo-20881: 20881
+      labels:
+        application: service-b
+        group: g2
+        interface: com.example.service.ServiceB
+        side: provider
+        version: 0.0.1
+---
+kind: ServiceEntry
+apiVersion: networking.istio.io/v1alpha3
+metadata:
+  name: com.example.service.ServiceC:g2:0.0.1
+  namespace: dubbo
+  labels:
+    path: com.example.service.ServiceC
+    registry: zookeeper
+  annotations: {}
+spec:
+  hosts:
+    - 'com.example.service.ServiceC:g2:0.0.1'
+  ports:
+    - number: 20882
+      protocol: DUBBO
+      name: dubbo-20882
+  resolution: STATIC
+  endpoints:
+    - address: 10.0.2.1
+      ports:
+        dubbo-20882: 20882
+      labels:
+        application: service-c
+        group: g2
+        interface: com.example.service.ServiceC
+        side: provider
+        version: 0.0.1
+---
+kind: ServiceEntry
+apiVersion: networking.istio.io/v1alpha3
+metadata:
+  name: not-really-exist-dubbo
+  namespace: dubbo
+  labels:
+    path: not-really-exist-dubbo.svc
+    registry: zookeeper
+  annotations: {}
+spec:
+  hosts:
+    - 'not-really-exist-dubbo.svc'
+  ports:
+    - number: 20880
+      protocol: DUBBO
+      name: dubbo-20880
+    - number: 20881
+      protocol: DUBBO
+      name: dubbo-20881
+    - number: 20882
+      protocol: DUBBO
+      name: dubbo-20882
+  resolution: STATIC

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/zookeeper/testdata/simple_with_dubbo_call_model.expected.yaml
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/zookeeper/testdata/simple_with_dubbo_call_model.expected.yaml
@@ -1,0 +1,202 @@
+---
+kind: ServiceEntry
+apiVersion: networking.istio.io/v1alpha3
+metadata:
+  name: com.example.service.ServiceA:g:0.0.1
+  namespace: dubbo
+  labels:
+    path: com.example.service.ServiceA
+    registry: zookeeper
+  annotations: {}
+spec:
+  hosts:
+    - 'com.example.service.ServiceA:g:0.0.1'
+  ports:
+    - number: 20880
+      protocol: DUBBO
+      name: dubbo-20880
+  resolution: STATIC
+  endpoints:
+    - address: 10.0.0.1
+      ports:
+        dubbo-20880: 20880
+      labels:
+        application: service-a
+        group: g
+        interface: com.example.service.ServiceA
+        side: provider
+        version: 0.0.1
+---
+kind: ServiceEntry
+apiVersion: networking.istio.io/v1alpha3
+metadata:
+  name: com.example.service.ServiceA:g:0.0.2
+  namespace: dubbo
+  labels:
+    path: com.example.service.ServiceA
+    registry: zookeeper
+  annotations: {}
+spec:
+  hosts:
+    - 'com.example.service.ServiceA:g:0.0.2'
+  ports:
+    - number: 20880
+      protocol: DUBBO
+      name: dubbo-20880
+  resolution: STATIC
+  endpoints:
+    - address: 10.0.0.2
+      ports:
+        dubbo-20880: 20880
+      labels:
+        application: service-a
+        group: g
+        interface: com.example.service.ServiceA
+        side: provider
+        version: 0.0.2
+    - address: 10.0.0.3
+      ports:
+        dubbo-20880: 20880
+      labels:
+        application: service-a
+        group: g
+        interface: com.example.service.ServiceA
+        side: provider
+        version: 0.0.2
+---
+kind: ServiceEntry
+apiVersion: networking.istio.io/v1alpha3
+metadata:
+  name: com.example.service.ServiceB:g:0.0.1
+  namespace: dubbo
+  labels:
+    path: com.example.service.ServiceB
+    registry: zookeeper
+  annotations: {}
+spec:
+  hosts:
+    - 'com.example.service.ServiceB:g:0.0.1'
+  ports:
+    - number: 20881
+      protocol: DUBBO
+      name: dubbo-20881
+  resolution: STATIC
+  endpoints:
+    - address: 10.0.1.1
+      ports:
+        dubbo-20881: 20881
+      labels:
+        application: service-b
+        group: g
+        interface: com.example.service.ServiceB
+        side: provider
+        version: 0.0.1
+---
+kind: ServiceEntry
+apiVersion: networking.istio.io/v1alpha3
+metadata:
+  name: com.example.service.ServiceB:g2:0.0.1
+  namespace: dubbo
+  labels:
+    path: com.example.service.ServiceB
+    registry: zookeeper
+  annotations: {}
+spec:
+  hosts:
+    - 'com.example.service.ServiceB:g2:0.0.1'
+  ports:
+    - number: 20881
+      protocol: DUBBO
+      name: dubbo-20881
+  resolution: STATIC
+  endpoints:
+    - address: 10.0.1.2
+      ports:
+        dubbo-20881: 20881
+      labels:
+        application: service-b
+        group: g2
+        interface: com.example.service.ServiceB
+        side: provider
+        version: 0.0.1
+---
+kind: ServiceEntry
+apiVersion: networking.istio.io/v1alpha3
+metadata:
+  name: com.example.service.ServiceC:g2:0.0.1
+  namespace: dubbo
+  labels:
+    path: com.example.service.ServiceC
+    registry: zookeeper
+  annotations: {}
+spec:
+  hosts:
+    - 'com.example.service.ServiceC:g2:0.0.1'
+  ports:
+    - number: 20882
+      protocol: DUBBO
+      name: dubbo-20882
+  resolution: STATIC
+  endpoints:
+    - address: 10.0.2.1
+      ports:
+        dubbo-20882: 20882
+      labels:
+        application: service-c
+        group: g2
+        interface: com.example.service.ServiceC
+        side: provider
+        version: 0.0.1
+---
+kind: Sidecar
+apiVersion: networking.istio.io/v1alpha3
+metadata:
+  name: service-a.dubbo.generated
+  namespace: dubbo
+  labels: {}
+  annotations:
+    sidecar.config.istio.io/nonNsSpec: 'true'
+spec:
+  workloadSelector:
+    labels:
+      application: service-a
+  egress:
+    - port:
+        protocol: DUBBO
+      hosts:
+        - '*/com.example.service.ServiceB:g2:0.0.1'
+        - '*/com.example.service.ServiceB:g:0.0.1'
+---
+kind: Sidecar
+apiVersion: networking.istio.io/v1alpha3
+metadata:
+  name: service-b.dubbo.generated
+  namespace: dubbo
+  labels: {}
+  annotations:
+    sidecar.config.istio.io/nonNsSpec: 'true'
+spec:
+  workloadSelector:
+    labels:
+      application: service-b
+  egress:
+    - port:
+        protocol: DUBBO
+      hosts:
+        - '*/com.example.service.ServiceC:g2:0.0.1'
+---
+kind: Sidecar
+apiVersion: networking.istio.io/v1alpha3
+metadata:
+  name: service-c.dubbo.generated
+  namespace: dubbo
+  labels: {}
+  annotations:
+    sidecar.config.istio.io/nonNsSpec: 'true'
+spec:
+  workloadSelector:
+    labels:
+      application: service-c
+  egress:
+    - port:
+        protocol: DUBBO

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/zookeeper/testdata/simple_with_dubbo_call_model_and_self_consume.expected.yaml
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/zookeeper/testdata/simple_with_dubbo_call_model_and_self_consume.expected.yaml
@@ -1,0 +1,208 @@
+---
+kind: ServiceEntry
+apiVersion: networking.istio.io/v1alpha3
+metadata:
+  name: com.example.service.ServiceA:g:0.0.1
+  namespace: dubbo
+  labels:
+    path: com.example.service.ServiceA
+    registry: zookeeper
+  annotations: {}
+spec:
+  hosts:
+    - 'com.example.service.ServiceA:g:0.0.1'
+  ports:
+    - number: 20880
+      protocol: DUBBO
+      name: dubbo-20880
+  resolution: STATIC
+  endpoints:
+    - address: 10.0.0.1
+      ports:
+        dubbo-20880: 20880
+      labels:
+        application: service-a
+        group: g
+        interface: com.example.service.ServiceA
+        side: provider
+        version: 0.0.1
+---
+kind: ServiceEntry
+apiVersion: networking.istio.io/v1alpha3
+metadata:
+  name: com.example.service.ServiceA:g:0.0.2
+  namespace: dubbo
+  labels:
+    path: com.example.service.ServiceA
+    registry: zookeeper
+  annotations: {}
+spec:
+  hosts:
+    - 'com.example.service.ServiceA:g:0.0.2'
+  ports:
+    - number: 20880
+      protocol: DUBBO
+      name: dubbo-20880
+  resolution: STATIC
+  endpoints:
+    - address: 10.0.0.2
+      ports:
+        dubbo-20880: 20880
+      labels:
+        application: service-a
+        group: g
+        interface: com.example.service.ServiceA
+        side: provider
+        version: 0.0.2
+    - address: 10.0.0.3
+      ports:
+        dubbo-20880: 20880
+      labels:
+        application: service-a
+        group: g
+        interface: com.example.service.ServiceA
+        side: provider
+        version: 0.0.2
+---
+kind: ServiceEntry
+apiVersion: networking.istio.io/v1alpha3
+metadata:
+  name: com.example.service.ServiceB:g:0.0.1
+  namespace: dubbo
+  labels:
+    path: com.example.service.ServiceB
+    registry: zookeeper
+  annotations: {}
+spec:
+  hosts:
+    - 'com.example.service.ServiceB:g:0.0.1'
+  ports:
+    - number: 20881
+      protocol: DUBBO
+      name: dubbo-20881
+  resolution: STATIC
+  endpoints:
+    - address: 10.0.1.1
+      ports:
+        dubbo-20881: 20881
+      labels:
+        application: service-b
+        group: g
+        interface: com.example.service.ServiceB
+        side: provider
+        version: 0.0.1
+---
+kind: ServiceEntry
+apiVersion: networking.istio.io/v1alpha3
+metadata:
+  name: com.example.service.ServiceB:g2:0.0.1
+  namespace: dubbo
+  labels:
+    path: com.example.service.ServiceB
+    registry: zookeeper
+  annotations: {}
+spec:
+  hosts:
+    - 'com.example.service.ServiceB:g2:0.0.1'
+  ports:
+    - number: 20881
+      protocol: DUBBO
+      name: dubbo-20881
+  resolution: STATIC
+  endpoints:
+    - address: 10.0.1.2
+      ports:
+        dubbo-20881: 20881
+      labels:
+        application: service-b
+        group: g2
+        interface: com.example.service.ServiceB
+        side: provider
+        version: 0.0.1
+---
+kind: ServiceEntry
+apiVersion: networking.istio.io/v1alpha3
+metadata:
+  name: com.example.service.ServiceC:g2:0.0.1
+  namespace: dubbo
+  labels:
+    path: com.example.service.ServiceC
+    registry: zookeeper
+  annotations: {}
+spec:
+  hosts:
+    - 'com.example.service.ServiceC:g2:0.0.1'
+  ports:
+    - number: 20882
+      protocol: DUBBO
+      name: dubbo-20882
+  resolution: STATIC
+  endpoints:
+    - address: 10.0.2.1
+      ports:
+        dubbo-20882: 20882
+      labels:
+        application: service-c
+        group: g2
+        interface: com.example.service.ServiceC
+        side: provider
+        version: 0.0.1
+---
+kind: Sidecar
+apiVersion: networking.istio.io/v1alpha3
+metadata:
+  name: service-a.dubbo.generated
+  namespace: dubbo
+  labels: {}
+  annotations:
+    sidecar.config.istio.io/nonNsSpec: 'true'
+spec:
+  workloadSelector:
+    labels:
+      application: service-a
+  egress:
+    - port:
+        protocol: DUBBO
+      hosts:
+        - '*/com.example.service.ServiceA:g:0.0.1'
+        - '*/com.example.service.ServiceA:g:0.0.2'
+        - '*/com.example.service.ServiceB:g2:0.0.1'
+        - '*/com.example.service.ServiceB:g:0.0.1'
+---
+kind: Sidecar
+apiVersion: networking.istio.io/v1alpha3
+metadata:
+  name: service-b.dubbo.generated
+  namespace: dubbo
+  labels: {}
+  annotations:
+    sidecar.config.istio.io/nonNsSpec: 'true'
+spec:
+  workloadSelector:
+    labels:
+      application: service-b
+  egress:
+    - port:
+        protocol: DUBBO
+      hosts:
+        - '*/com.example.service.ServiceB:g2:0.0.1'
+        - '*/com.example.service.ServiceB:g:0.0.1'
+        - '*/com.example.service.ServiceC:g2:0.0.1'
+---
+kind: Sidecar
+apiVersion: networking.istio.io/v1alpha3
+metadata:
+  name: service-c.dubbo.generated
+  namespace: dubbo
+  labels: {}
+  annotations:
+    sidecar.config.istio.io/nonNsSpec: 'true'
+spec:
+  workloadSelector:
+    labels:
+      application: service-c
+  egress:
+    - port:
+        protocol: DUBBO
+      hosts:
+        - '*/com.example.service.ServiceC:g2:0.0.1'

--- a/staging/src/slime.io/slime/modules/meshregistry/pkg/source/zookeeper/watching.go
+++ b/staging/src/slime.io/slime/modules/meshregistry/pkg/source/zookeeper/watching.go
@@ -110,7 +110,7 @@ type ServiceEvent struct {
 }
 
 type EndpointWatcherOpts struct {
-	conn                       *zkConn
+	conn                       ZkConn
 	endpointUpdateFunc         func(providers, consumers, configurators []string, serverPath string)
 	serviceDeleteFunc          func(path string)
 	consumerPath, providerPath string
@@ -143,7 +143,7 @@ func NewEndpointWatcher(servicePath string, opts EndpointWatcherOpts) *EndpointW
 }
 
 type EndpointWatcher struct {
-	conn *zkConn
+	conn ZkConn
 
 	// /{root:dubbo}/{service:<service-name>}
 	// - /{root:dubbo}/{service:<service-name>}/providers/dubbo://ip:port/{provider_service}}?xxx
@@ -422,7 +422,7 @@ var dubboExcludeServicePath = []string{
 type ServiceWatcher struct {
 	ctx context.Context
 
-	conn                       *zkConn
+	conn                       ZkConn
 	rootPath                   string
 	endpointUpdateFunc         func([]string, []string, []string, string)
 	serviceDeleteFunc          func(string)


### PR DESCRIPTION
In pr we built model conversion unit tests for sources including nacos, eureka, and zookeeper. The tests focus on the validation of the registry's raw service model data to the expected istio ServiceEntry.

As requirements were created and changed, we continued to extend the source parameters that influenced what the raw service model would look like transformed into the target ServiceEntry. Historically, we validated new requirements by building actual registry registration demo services, which was very time and effort consuming. Using the unit test approach in pr, it is possible to quickly validate the new logic.

The coverage is increased as follows:
```
# before
$ go test -timeout 30s -cover slime.io/slime/modules/meshregistry/pkg/source/...
?       slime.io/slime/modules/meshregistry/pkg/source/eureka   [no test files]
?       slime.io/slime/modules/meshregistry/pkg/source/k8s      [no test files]
?       slime.io/slime/modules/meshregistry/pkg/source/k8s/fs   [no test files]
?       slime.io/slime/modules/meshregistry/pkg/source/nacos    [no test files]
ok      slime.io/slime/modules/meshregistry/pkg/source  0.021s  coverage: 47.6% of statements
ok      slime.io/slime/modules/meshregistry/pkg/source/zookeeper        0.018s  coverage: 1.8% of statements

# after
$ go test -timeout 30s -cover slime.io/slime/modules/meshregistry/pkg/source/...
ok      slime.io/slime/modules/meshregistry/pkg/source  0.021s  coverage: 47.6% of statements
?       slime.io/slime/modules/meshregistry/pkg/source/k8s      [no test files]
?       slime.io/slime/modules/meshregistry/pkg/source/k8s/fs   [no test files]
ok      slime.io/slime/modules/meshregistry/pkg/source/eureka   0.032s  coverage: 45.0% of statements
ok      slime.io/slime/modules/meshregistry/pkg/source/nacos    0.030s  coverage: 26.5% of statements
ok      slime.io/slime/modules/meshregistry/pkg/source/sourcetest       0.020s  coverage: 13.3% of statements
ok      slime.io/slime/modules/meshregistry/pkg/source/zookeeper        0.047s  coverage: 37.3% of statements
```
