### PR TITLE
limiter: generate ef with workload selectror miss match pod for outbound or gateway

### DIFF
--- a/staging/src/slime.io/slime/modules/limiter/controllers/envoy_global_limit.go
+++ b/staging/src/slime.io/slime/modules/limiter/controllers/envoy_global_limit.go
@@ -356,6 +356,10 @@ func constructNewConfig(desc []*model.Descriptor, domain string) string {
 }
 
 func generateDescriptorKey(item *microservicev1alpha2.SmartLimitDescriptor, loc types.NamespacedName) string {
+	// Note: Unit tests have revealed unstable results when using the Adler-32 algorithm to
+	// hash the text format of protobuf messages. 
+	// Given Adler-32's inherent determinism and excluding changes to the proto API or test materials,
+	// the source of this instability remains under investigation.
 	id := adler32.Checksum([]byte(item.String() + loc.String()))
 	return fmt.Sprintf("RequestHeader[%s.%s]-Id[%d]", loc.Name, loc.Namespace, id)
 }

--- a/staging/src/slime.io/slime/modules/limiter/controllers/smartlimiter_controller.go
+++ b/staging/src/slime.io/slime/modules/limiter/controllers/smartlimiter_controller.go
@@ -235,11 +235,13 @@ func (r *SmartLimiterReconciler) Validate(instance *limiterv1alpha2.SmartLimiter
 	gateway := instance.Spec.Gateway
 	sidecarOutbound := false
 
-	var target *limiterv1alpha2.Target
-
 	for _, descriptors := range instance.Spec.Sets {
 		for _, descriptor := range descriptors.Descriptor_ {
-			if descriptor.Target == nil && instance.Spec.Target == nil {
+			target := instance.Spec.Target
+			if descriptor.Target != nil {
+				target = descriptor.Target
+			}
+			if target == nil {
 				return sidecarOutbound, gateway, fmt.Errorf("invalid target")
 			}
 			if descriptor.Action == nil {

--- a/staging/src/slime.io/slime/modules/limiter/controllers/smartlimiter_controller_test.go
+++ b/staging/src/slime.io/slime/modules/limiter/controllers/smartlimiter_controller_test.go
@@ -83,11 +83,21 @@ var _ = Describe("SmartlimiterReconciler", func() {
 				_ = k8sClient.Delete(ctx, want)
 			}()
 		},
-		Entry("method", "./testdata/base_objs.local.yaml",
-			"./testdata/limit_by_method.local.yaml", "./testdata/limit_by_method.local.ef.expect.yaml"),
-		Entry("query", "./testdata/base_objs.local.yaml",
-			"./testdata/limit_by_query.local.yaml", "./testdata/limit_by_query.local.ef.expect.yaml"),
-		Entry("sourceIP", "./testdata/base_objs.local.yaml",
-			"./testdata/limit_by_sourceIP.local.yaml", "./testdata/limit_by_sourceIP.local.ef.expect.yaml"),
+		Entry("method",
+			"./testdata/base_objs.local.yaml",
+			"./testdata/limit_by_method.local.yaml",
+			"./testdata/limit_by_method.local.ef.expect.yaml"),
+		Entry("query",
+			"./testdata/base_objs.local.yaml",
+			"./testdata/limit_by_query.local.yaml",
+			"./testdata/limit_by_query.local.ef.expect.yaml"),
+		Entry("sourceIP",
+			"./testdata/base_objs.local.yaml",
+			"./testdata/limit_by_sourceIP.local.yaml",
+			"./testdata/limit_by_sourceIP.local.ef.expect.yaml"),
+		Entry("gateway-with-selector-but-mismatch",
+			"./testdata/base_objs.local.yaml",
+			"./testdata/limit_outbound_with_mismatch_selector.local.yaml",
+			"./testdata/limit_outbound_with_mismatch_selector.local.ef.expect.yaml"),
 	)
 })

--- a/staging/src/slime.io/slime/modules/limiter/controllers/suite_test.go
+++ b/staging/src/slime.io/slime/modules/limiter/controllers/suite_test.go
@@ -25,7 +25,6 @@ import (
 	. "github.com/onsi/gomega"
 	networkingv1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	"k8s.io/apimachinery/pkg/runtime"
-	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	k8sscheme "k8s.io/client-go/kubernetes/scheme"
@@ -51,7 +50,6 @@ var (
 	ctx       context.Context
 	cancel    context.CancelFunc
 	scheme    = runtime.NewScheme()
-	codecs    = serializer.NewCodecFactory(scheme)
 
 	slimeEnv bootstrap.Environment
 )

--- a/staging/src/slime.io/slime/modules/limiter/controllers/testdata/limit_by_method.local.ef.expect.yaml
+++ b/staging/src/slime.io/slime/modules/limiter/controllers/testdata/limit_by_method.local.ef.expect.yaml
@@ -21,7 +21,7 @@ spec:
           rate_limits:
           - actions:
             - header_value_match:
-                descriptor_value: Service[hello.default]-Id[2757373597]
+                descriptor_value: Service[hello.default]-Id[1092235069]
                 headers:
                 - exact_match: GET
                   name: :method
@@ -43,7 +43,7 @@ spec:
               descriptors:
               - entries:
                 - key: header_match
-                  value: Service[hello.default]-Id[2757373597]
+                  value: Service[hello.default]-Id[1092235069]
                 tokenBucket:
                   fillInterval: 1s
                   maxTokens: 10

--- a/staging/src/slime.io/slime/modules/limiter/controllers/testdata/limit_outbound_with_mismatch_selector.local.ef.expect.yaml
+++ b/staging/src/slime.io/slime/modules/limiter/controllers/testdata/limit_outbound_with_mismatch_selector.local.ef.expect.yaml
@@ -3,36 +3,32 @@ kind: EnvoyFilter
 metadata:
   labels:
     istio.io/rev: default
-  name: hello.default.ratelimit
+  name: withselector-missing-match-workload.ratelimit
   namespace: default
 spec:
   configPatches:
   - applyTo: HTTP_ROUTE
     match:
-      context: SIDECAR_INBOUND
+      context: GATEWAY
       routeConfiguration:
         vhost:
           route:
-            name: default
+            name: foo
     patch:
       operation: MERGE
       value:
         route:
           rate_limits:
           - actions:
-            - query_parameter_value_match:
-                descriptor_value: Service[hello.default]-Id[2197174159]
-                query_parameters:
-                - name: foo
-                  string_match:
-                    prefix: bar
+            - generic_key:
+                descriptor_value: Service[withselector-missing-match-workload.default]-Id[2597136639]
   - applyTo: HTTP_ROUTE
     match:
-      context: SIDECAR_INBOUND
+      context: GATEWAY
       routeConfiguration:
         vhost:
           route:
-            name: default
+            name: foo
     patch:
       operation: MERGE
       value:
@@ -43,12 +39,12 @@ spec:
             value:
               descriptors:
               - entries:
-                - key: query_match
-                  value: Service[hello.default]-Id[2197174159]
+                - key: generic_key
+                  value: Service[withselector-missing-match-workload.default]-Id[2597136639]
                 tokenBucket:
-                  fillInterval: 1s
-                  maxTokens: 10
-                  tokensPerFill: 10
+                  fillInterval: 60s
+                  maxTokens: 50
+                  tokensPerFill: 50
               filterEnabled:
                 defaultValue:
                   numerator: 100
@@ -64,4 +60,4 @@ spec:
                 tokensPerFill: 100000
   workloadSelector:
     labels:
-      app: hello
+      app: not-matched-any-workload

--- a/staging/src/slime.io/slime/modules/limiter/controllers/testdata/limit_outbound_with_mismatch_selector.local.yaml
+++ b/staging/src/slime.io/slime/modules/limiter/controllers/testdata/limit_outbound_with_mismatch_selector.local.yaml
@@ -1,0 +1,24 @@
+apiVersion: microservice.slime.io/v1alpha2
+kind: SmartLimiter
+metadata:
+  labels:
+    istio.io/rev: default
+  name: withselector-missing-match-workload
+  namespace: default
+spec:
+  gateway: true
+  sets:
+    _base:
+      descriptor:
+      - action:
+          fill_interval:
+            seconds: 60
+          quota: "50"
+          strategy: single
+        condition: "true"
+  target:
+    direction: outbound
+    route:
+    - /foo
+  workloadSelector:
+    app: not-matched-any-workload


### PR DESCRIPTION
#432 引入基于 workload 的均分限流时，移除了对于出方向流量场景时，不强制要求 workload 匹配的支持，无法适配 vm 场景。该提交不影响均分限流的基础上，用于找回 #432 之前版本对于 vm 场景的支持。